### PR TITLE
Crash if session was flushed before commit (with validity strategy)

### DIFF
--- a/tests/test_exotic_operation_combos.py
+++ b/tests/test_exotic_operation_combos.py
@@ -64,3 +64,7 @@ class TestExoticOperationCombos(TestCase):
         assert article2.versions.count() == 2
         assert article2.versions[0].operation_type == 0
         assert article2.versions[1].operation_type == 1
+
+
+class TestExoticOperationCombosWithValidityStrategy(TestExoticOperationCombos):
+    versioning_strategy = 'validity'


### PR DESCRIPTION
Issue #39 is fixed only for subquery strategy

Test from pull request below crashes with

``` python
E       IntegrityError: (IntegrityError) duplicate key value violates unique constraint "article_history_pkey"
E       DETAIL:  Key (id, transaction_id)=(1, 1) already exists.
E        'INSERT INTO article_history (id, name, content, description, transaction_id, end_transaction_id, operation_type) VALUES (%(id)s, %(name)s, %(content)s, %(description)s, %(transaction_id)s, %(end_transaction_id)s, %(operation_type)s)' {'name': u'Some article', 'content': u'Some content', 'end_transaction_id': None, 'operation_type': 0, 'id': 1, 'transaction_id': 1L, 'description': None}
```

Flask==0.10.1
SQLAlchemy==0.9.2
SQLAlchemy-Utils==0.23.5
SQLAlchemy-i18n==0.8.2
flexmock==0.9.7
inflection==0.2.0
pytest==2.5.2
six==1.5.2
toolz==0.5.2

OS: Ubuntu 12.04 64-bit
PostgreSQL version: 9.1.3-2
