### PR TITLE
Version objects of subclasses aren't instances of subclass history

### DIFF
--- a/tests/test_join_table_inheritance.py
+++ b/tests/test_join_table_inheritance.py
@@ -1,3 +1,4 @@
+from six import PY3
 import sqlalchemy as sa
 from tests import TestCase
 
@@ -53,6 +54,20 @@ class TestJoinTableInheritance(TestCase):
         assert self.BlogPostHistory.__table__.name == 'blog_post_history'
         assert issubclass(self.ArticleHistory, self.TextItemHistory)
         assert issubclass(self.BlogPostHistory, self.TextItemHistory)
+
+    def test_each_object_has_distinct_history_class(self):
+        article = self.Article()
+        blogpost = self.BlogPost()
+        textitem = self.TextItem()
+
+        self.session.add(article)
+        self.session.add(blogpost)
+        self.session.add(textitem)
+        self.session.commit()
+
+        assert type(textitem.versions[0]) == self.TextItemHistory
+        assert type(article.versions[0]) == self.ArticleHistory
+        assert type(blogpost.versions[0]) == self.BlogPostHistory
 
     def test_all_tables_contain_transaction_id_column(self):
         assert 'transaction_id' in self.TextItemHistory.__table__.c


### PR DESCRIPTION
See tests in pull request

Flask==0.10.1
SQLAlchemy==0.9.2
SQLAlchemy-Utils==0.23.5
SQLAlchemy-i18n==0.8.2
flexmock==0.9.7
inflection==0.2.0
pytest==2.5.2
six==1.5.2
toolz==0.5.2

OS: Ubuntu 12.04 64-bit
PostgreSQL version: 9.1.3-2
