### PR TITLE
Test previous/next on multiple articles

### DIFF
--- a/sqlalchemy_continuum/fetcher.py
+++ b/sqlalchemy_continuum/fetcher.py
@@ -69,9 +69,13 @@ class HistoryObjectFetcher(object):
                 from_obj=[alias.__table__]
             )
             .where(
-                op(
-                    getattr(alias, tx_column_name(obj)),
-                    getattr(obj, tx_column_name(obj))
+                sa.and_(
+                    op(
+                        getattr(alias, tx_column_name(obj)),
+                        getattr(obj, tx_column_name(obj))
+                    ),
+                    # *self._pk_correlation_condition(alias)
+                    alias.id == obj.id
                 )
             )
             .correlate(alias.__table__)

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -56,6 +56,50 @@ class VersionModelAccessorsTestCase(TestCase):
             .order_by(self.ArticleHistory.id)
         ).all()[-1]
         assert version.previous.previous
+        
+    def test_previous_two_versions(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        self.session.add(article)
+        self.session.commit()
+        article2 = self.Article()
+        article2.name = u'Second article'
+        article2.content = u'Second article'
+        self.session.add(article2)
+        self.session.commit()
+        
+        article.name = u'Updated article'
+        self.session.commit()
+        article.name = u'Updated article 2'
+        self.session.commit()
+        
+        assert article.versions[2].previous
+        assert article.versions[1].previous
+        assert article.versions[2].previous == article.versions[1]
+        assert article.versions[1].previous == article.versions[0]
+        
+    def test_next_two_versions(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        self.session.add(article)
+        self.session.commit()
+        article2 = self.Article()
+        article2.name = u'Second article'
+        article2.content = u'Second article'
+        self.session.add(article2)
+        self.session.commit()
+        
+        article.name = u'Updated article'
+        self.session.commit()
+        article.name = u'Updated article 2'
+        self.session.commit()
+        
+        assert article.versions[0].next
+        assert article.versions[1].next
+        assert article.versions[0].next == article.versions[1]
+        assert article.versions[1].next == article.versions[2]
 
     def test_next_for_last_version(self):
         article = self.Article()


### PR DESCRIPTION
Tests for previous/next versions when more than 1 object exists.

These tests will fail without the modified where clause in fetcher.py
