### PR TITLE
Adds the ability to specify a schema for versioning tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Pycharm/IntelliJ
+.idea

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -150,5 +150,6 @@ class TableBuilder(object):
             extends.name if extends is not None else self.table_name,
             self.parent_table.metadata,
             *columns,
-            extend_existing=extends is not None
+            extend_existing=extends is not None,
+            schema=self.option('table_schema') or self.parent_table.schema
         )


### PR DESCRIPTION
Context: we want to version all of our objects, but keep all the version related tables in a separate 'audit' schema.
