### PR TITLE
Versioning issues on session.flush

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+#Pycharm
+.idea

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -370,6 +370,16 @@ class DeleteUpsertSQL(UpsertSQL):
 
 
 class InsertUpsertSQL(UpsertSQL):
+    """
+    AFTER INSERT on parent_table:
+    exists (NEW.[pks], current_tx_id) in version_table?
+    No:
+        INSERT with operation_type = 0
+    Yes:
+        (means target was deleted and re-inserted in the same transaction,
+         so its actually an update)
+        UPDATE with operation_type = 1
+    """
     operation_type = 0
 
     def build_mod_tracking_values(self):

--- a/sqlalchemy_continuum/operation.py
+++ b/sqlalchemy_continuum/operation.py
@@ -98,7 +98,17 @@ class Operations(object):
                     del state_copy[rel_key]
 
         if state_copy:
-            self.add(Operation(target, Operation.UPDATE))
+            key = self.format_key(target)
+            # if the object has already been added with an INSERT,
+            # then this is a modification within the same transaction and
+            # this is still an INSERT
+            if (target in self and
+                self[key].type == Operation.INSERT):
+                operation = Operation.INSERT
+            else:
+                operation = Operation.UPDATE
+
+            self.add(Operation(target, operation))
 
     def add_delete(self, target):
         self.add(Operation(target, Operation.DELETE))

--- a/sqlalchemy_continuum/operation.py
+++ b/sqlalchemy_continuum/operation.py
@@ -8,8 +8,6 @@ import six
 import sqlalchemy as sa
 from sqlalchemy_utils import identity, get_primary_keys, has_changes
 
-from .utils import commited_identity
-
 class Operation(object):
     INSERT = 0
     UPDATE = 1
@@ -124,7 +122,7 @@ class Operations(object):
         mapper = sa.inspect(target).mapper
         for pk in mapper.primary_key:
             if has_changes(target, mapper.get_property_by_column(pk).key):
-                old_key = target.__class__, commited_identity(target)
+                old_key = target.__class__, sa.inspect(target).identity
                 if old_key in self.objects:
                     # replace old key with the new one
                     self.objects[key] = self.objects.pop(old_key)

--- a/sqlalchemy_continuum/plugins/transaction_changes.py
+++ b/sqlalchemy_continuum/plugins/transaction_changes.py
@@ -107,6 +107,7 @@ class TransactionChangesPlugin(Plugin):
                 primaryjoin=(
                     self.model_class.transaction_id == transaction_column
                 ),
-                foreign_keys=[self.model_class.transaction_id]
+                foreign_keys=[self.model_class.transaction_id],
+                passive_deletes='all'
             )
         parent_cls.__versioned__['transaction_changes'] = self.model_class

--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -8,8 +8,7 @@ from .utils import (
     version_class,
     is_session_modified,
     tx_column_name,
-    versioned_column_properties,
-    commited_identity
+    versioned_column_properties
 )
 
 
@@ -133,7 +132,7 @@ class UnitOfWork(object):
         mapper = sa.inspect(target).mapper
         for pk in mapper.primary_key:
             if has_changes(target, mapper.get_property_by_column(pk).key):
-                old_key = self._create_key(target, commited_identity(target))
+                old_key = self._create_key(target, sa.inspect(target).identity)
                 if old_key in self.version_objs:
                     # replace old key with the new one
                     self.version_objs[key] = self.version_objs.pop(old_key)

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -413,3 +413,20 @@ def changeset(obj):
                 if new_value:
                     data[prop.key] = [new_value, old_value]
     return data
+
+
+def commited_identity(obj):
+    """Returns a tuple of the primary keys of the object without any
+    modifications that may have occured within the session
+    """
+    old_pks = []
+    obj_inspect = sa.inspect(obj)
+    mapper = obj_inspect.mapper
+    for column in get_primary_keys(obj).itervalues():
+        old_pk = obj_inspect.attrs.get(
+            mapper.get_property_by_column(column).key).history.deleted
+        if old_pk:
+            old_pks.append(old_pk[0])
+        else:
+            old_pks.append(getattr(obj, column.name))
+    return tuple(old_pks)

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -413,20 +413,3 @@ def changeset(obj):
                 if new_value:
                     data[prop.key] = [new_value, old_value]
     return data
-
-
-def commited_identity(obj):
-    """Returns a tuple of the primary keys of the object without any
-    modifications that may have occured within the session
-    """
-    old_pks = []
-    obj_inspect = sa.inspect(obj)
-    mapper = obj_inspect.mapper
-    for column in get_primary_keys(obj).itervalues():
-        old_pk = obj_inspect.attrs.get(
-            mapper.get_property_by_column(column).key).history.deleted
-        if old_pk:
-            old_pks.append(old_pk[0])
-        else:
-            old_pks.append(getattr(obj, column.name))
-    return tuple(old_pks)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,4 +1,6 @@
 import sqlalchemy as sa
+from sqlalchemy_continuum import Operation, version_class
+
 from tests import TestCase
 
 
@@ -24,6 +26,25 @@ class TestDelete(TestCase):
         assert len(versions) == 2
         assert versions[1].name == u'Some article'
         assert versions[1].content == u'Some content'
+
+    def test_modify_primary_key(self):
+        """Test that modifying the primary key within the same transaction
+        maintains correct delete behavior"""
+        article = self.Article(name=u'Article name')
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = u'Second name'
+        self.session.flush()
+        article.id += 1
+        self.session.delete(article)
+        self.session.commit()
+
+        ArticleVersion = version_class(self.Article)
+        versions_q = self.session.query(ArticleVersion)\
+                        .order_by(ArticleVersion.transaction_id)
+        assert versions_q.count() == 2
+        assert versions_q[1].operation_type == Operation.DELETE
 
 
 class TestDeleteWithDeferredColumn(TestCase):

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -27,6 +27,38 @@ class TestDelete(TestCase):
         assert versions[1].name == u'Some article'
         assert versions[1].content == u'Some content'
 
+    def test_insert_delete_in_single_transaction(self):
+        """Test that when an object is created and then deleted within the
+        same transaction, no history entry is created.
+        """
+        article = self.Article(name=u'Article name')
+        self.session.add(article)
+        self.session.flush()
+
+        self.session.delete(article)
+        self.session.commit()
+
+        ArticleVersion = version_class(self.Article)
+        assert self.session.query(ArticleVersion).count() == 0
+
+    def test_update_delete_in_single_transaction(self):
+        """Test that when an object is updated and then deleted within the
+        same transaction, the operation type DELETE is stored.
+        """
+        article = self.Article(name=u'Article name')
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = u'Updated name'
+        self.session.flush()
+        self.session.delete(article)
+        self.session.commit()
+
+        ArticleVersion = version_class(self.Article)
+        versions_query = self.session.query(self.ArticleVersion)
+        assert versions_query.count() == 2
+        assert versions_query[1].operation_type == Operation.DELETE
+
     def test_modify_primary_key(self):
         """Test that modifying the primary key within the same transaction
         maintains correct delete behavior"""

--- a/tests/test_exotic_operation_combos.py
+++ b/tests/test_exotic_operation_combos.py
@@ -40,6 +40,9 @@ class ExoticOperationCombosTestCase(TestCase):
         assert article2.versions[1].operation_type == 1
 
     def test_replace_deleted_object_with_update(self):
+        """Test that deleting an object and hijacking its primary key results
+        in turning the operation_type = 2 to an operation_type = 1
+        """
         article = self.Article()
         article.name = u'Some article'
         article.content = u'Some content'

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from sqlalchemy_continuum import count_versions, versioning_manager
+from sqlalchemy_continuum import count_versions, versioning_manager, Operation
 
 from tests import TestCase
 
@@ -38,6 +38,18 @@ class TestInsert(TestCase):
         self.session.commit()
         assert article.versions.count() == 1
         assert article2.versions.count() == 1
+
+    def test_multiple_flushes_store_operation_type(self):
+        """Test that after multiple flushes that affect a newly created object,
+        the insert operation type is commited
+        """
+        article = self.Article(name=u"Article name")
+        self.session.add(article)
+        self.session.flush()
+        article.name = u"Changed my mind"
+        self.session.commit()
+        assert article.versions.count() == 1
+        assert article.versions[0].operation_type == Operation.INSERT
 
 
 class TestInsertWithDeferredColumn(TestCase):


### PR DESCRIPTION
Hey, opening a pull request with some fixes related to mid-transaction flushes. Check the added tests to see what I think the expected behavior should be
- Keep the version's type as INSERT when a new object is flushed and then modified within the same single transaction. Currently there is no insert entry ever created.
- Ensure the same versioning behavior when primary keys of objects are modified after a flush, with the behavior that you get when they are modified without a flush.

Update:
- When a new object is created, flushed, then deleted (all in the same transaction), no version entry to be saved.
- Postgres triggers have also been updated.
