### PR TITLE
Restore relationships

### DIFF
--- a/sqlalchemy_continuum/reverter.py
+++ b/sqlalchemy_continuum/reverter.py
@@ -99,8 +99,8 @@ class Reverter(object):
                 self.revert_relationship(prop)
 
     def __call__(self):
-        if self.obj in self.visited_objects and self.obj.operation_type != Operation.DELETE:
-            return self.version_parent
+        if self.obj in self.visited_objects:
+            return None if self.obj.operation_type == Operation.DELETE else self.version_parent
 
         if self.obj.operation_type == Operation.DELETE:
             self.session.delete(self.version_parent)

--- a/sqlalchemy_continuum/reverter.py
+++ b/sqlalchemy_continuum/reverter.py
@@ -76,7 +76,10 @@ class Reverter(object):
                     value = self.revert_child(child_obj, prop)
                     if value:
                         values.append(value)
-                map(self.session.delete, filter(lambda v: v not in values, getattr(self.version_parent, prop.key, [])))
+
+                for value in getattr(self.version_parent, prop.key, []):
+                    if value not in values:
+                        self.session.delete(value)
             else:
                 self.revert_child(getattr(self.obj, prop.key), prop)
 

--- a/sqlalchemy_continuum/reverter.py
+++ b/sqlalchemy_continuum/reverter.py
@@ -20,12 +20,13 @@ class ReverterException(Exception):
 
 
 class Reverter(object):
-    def __init__(self, obj, visited_objects=[], relations=[]):
-        self.visited_objects = visited_objects
+    def __init__(self, obj, visited_objects=None, relations=[]):
+        self.visited_objects = visited_objects or []
         self.obj = obj
         self.version_parent = self.obj.version_parent
         self.parent_class = parent_class(self.obj.__class__)
         self.parent_mapper = sa.inspect(self.parent_class)
+        self.session = sa.orm.object_session(self.obj)
 
         self.relations = list(relations)
         for path in relations:
@@ -70,8 +71,12 @@ class Reverter(object):
             self.revert_association(prop)
         else:
             if prop.uselist:
-                for value in getattr(self.obj, prop.key):
-                    self.revert_child(value, prop)
+                values = []
+                for child_obj in getattr(self.obj, prop.key):
+                    value = self.revert_child(child_obj, prop)
+                    if value:
+                        values.append(value)
+                map(self.session.delete, filter(lambda v: v not in values, getattr(self.version_parent, prop.key, [])))
             else:
                 self.revert_child(getattr(self.obj, prop.key), prop)
 
@@ -94,13 +99,11 @@ class Reverter(object):
                 self.revert_relationship(prop)
 
     def __call__(self):
-        if self.obj in self.visited_objects:
-            return
-
-        session = sa.orm.object_session(self.obj)
+        if self.obj in self.visited_objects and self.obj.operation_type != Operation.DELETE:
+            return self.version_parent
 
         if self.obj.operation_type == Operation.DELETE:
-            session.delete(self.version_parent)
+            self.session.delete(self.version_parent)
             return
 
         self.visited_objects.append(self.obj)
@@ -108,7 +111,6 @@ class Reverter(object):
         # Check if parent object has been deleted
         if self.version_parent is None:
             self.version_parent = parent_class(self.obj.__class__)()
-            session.add(self.version_parent)
 
         # Before reifying relations we need to reify object properties. This
         # is needed because reifying relations might need to flush the session
@@ -116,5 +118,6 @@ class Reverter(object):
         # into parent object (if parent object has not null constraints).
         self.revert_properties()
         self.revert_relationships()
+        self.session.add(self.version_parent)
 
         return self.version_parent

--- a/tests/test_revert.py
+++ b/tests/test_revert.py
@@ -89,6 +89,30 @@ class RevertTestCase(TestCase):
         assert len(article.tags) == 1
         assert article.tags[0].name == u'some tag'
 
+    def test_revert_version_with_new_one_to_many_relation(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        article.tags.append(self.Tag(name=u'some tag'))
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        article.tags.append(self.Tag(name=u'some other tag'))
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        assert len(article.tags) == 2
+        assert len(article.versions[0].tags) == 1
+        assert article.versions[0].tags[0].article
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+        assert len(article.tags) == 1
+        assert article.tags[0].name == u'some tag'
+
 
 class TestRevertWithDefaultVersioningStrategy(RevertTestCase):
     pass


### PR DESCRIPTION
Restores one-to-many relationships to their previous state, removing items added since that version as described in issue #102.