### PR TITLE
Fix some relationship changes not counted as modifications

### DIFF
--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -203,7 +203,7 @@ def versioned_column_properties(obj_or_class):
             yield getattr(mapper.attrs, key)
 
 
-def versioned_relationships(obj):
+def versioned_relationships(obj, versioned_column_keys):
     """
     Return all versioned relationships for given versioned SQLAlchemy
     declarative model object.
@@ -211,7 +211,7 @@ def versioned_relationships(obj):
     :param obj: SQLAlchemy declarative model object
     """
     for prop in sa.inspect(obj.__class__).relationships:
-        if is_versioned(prop.mapper.class_):
+        if any(c.key in versioned_column_keys for c in prop.local_columns):
             yield prop
 
 
@@ -310,7 +310,8 @@ def is_modified(obj):
         prop.key for prop in versioned_column_properties(obj)
     ]
     versioned_relationship_keys = [
-        prop.key for prop in versioned_relationships(obj)
+        prop.key
+        for prop in versioned_relationships(obj, versioned_column_keys)
     ]
     for key, attr in sa.inspect(obj).attrs.items():
         if key in column_names:

--- a/tests/relationships/test_non_versioned_classes.py
+++ b/tests/relationships/test_non_versioned_classes.py
@@ -36,6 +36,20 @@ class TestRelationshipToNonVersionedClass(TestCase):
 
         assert isinstance(article.versions[0].author, self.User)
 
+    def test_change_relationship(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        user = self.User(name=u'Some user')
+        self.session.add(article)
+        self.session.add(user)
+        self.session.commit()
+
+        assert article.versions.count() == 1
+        article.author = user
+        self.session.commit()
+        assert article.versions.count() == 2
+
 
 class TestManyToManyRelationshipToNonVersionedClass(TestCase):
     def create_models(self):


### PR DESCRIPTION
`article.author = user` effectively changes `article.author_id` column. This change was not counted as modification if `User` model is not versioned although `article.author_id` column is versioned.