### PR TITLE
fixes for Oracle 

### DIFF
--- a/sqlalchemy_continuum/plugins/activity.py
+++ b/sqlalchemy_continuum/plugins/activity.py
@@ -200,7 +200,7 @@ from ..utils import version_class, version_obj
 
 class ActivityBase(object):
     id = sa.Column(sa.BigInteger,
-                   sa.schema.Sequence('id_seq_cont_activity'),
+                   sa.schema.Sequence('activity_base_id_seq'),
                    primary_key=True, 
                    autoincrement=True
                    )

--- a/sqlalchemy_continuum/plugins/activity.py
+++ b/sqlalchemy_continuum/plugins/activity.py
@@ -199,7 +199,11 @@ from ..utils import version_class, version_obj
 
 
 class ActivityBase(object):
-    id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
+    id = sa.Column(sa.BigInteger,
+                   sa.schema.Sequence('id_seq_cont_activity'),
+                   primary_key=True, 
+                   autoincrement=True
+                   )
 
     verb = sa.Column(sa.Unicode(255))
 

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -122,7 +122,7 @@ class TransactionFactory(ModelFactory):
             __versioning_manager__ = manager
 
             id = sa.Column(
-                sa.types.Integer,
+                sa.types.BigInteger,
                 sa.schema.Sequence('transaction_id_seq'),
                 primary_key=True,
                 autoincrement=True

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -123,7 +123,7 @@ class TransactionFactory(ModelFactory):
 
             id = sa.Column(
                 sa.types.Integer,
-                sa.schema.Sequence('id_seq_cont_transaction'),
+                sa.schema.Sequence('transaction_id_seq'),
                 primary_key=True,
                 autoincrement=True
             )

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -1,3 +1,4 @@
+
 from datetime import datetime
 
 try:
@@ -112,6 +113,7 @@ class TransactionFactory(ModelFactory):
         """
         Create Transaction class.
         """
+	
         class Transaction(
             manager.declarative_base,
             TransactionBase
@@ -120,7 +122,8 @@ class TransactionFactory(ModelFactory):
             __versioning_manager__ = manager
 
             id = sa.Column(
-                sa.types.BigInteger,
+                sa.types.Integer,
+                sa.schema.Sequence('id_seq_cont_transaction'),
                 primary_key=True,
                 autoincrement=True
             )


### PR DESCRIPTION
As Oracle does not have/respect SQLAlchemy's "autoincrement" (at leat not until Oracle v 11), this PR 
adds explicit Sequences to the Primary Key column ("id") on the Transaction and Activity tables. 
