### PR TITLE
Option to specify a different schema for version tables

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -88,7 +88,8 @@ class VersioningManager(object):
             'end_transaction_column_name': 'end_transaction_id',
             'operation_type_column_name': 'operation_type',
             'strategy': 'validity',
-            'use_module_name': False
+            'use_module_name': False,
+            'table_schema': None,
         }
         if plugins is None:
             self.plugins = []

--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -316,8 +316,9 @@ class RelationshipBuilder(object):
             column.table
         )
         metadata = column.table.metadata
-        if metadata.schema:
-            table_name = metadata.schema + '.' + builder.table_name
+
+        if column.table.version_schema:
+            table_name = column.table.version_schema + '.' + builder.table_name
         else:
             table_name = builder.table_name
 

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -120,6 +120,10 @@ class TableBuilder(object):
         self.parent_table = parent_table
         self.model = model
 
+        #  Add version_schema attribute to parent_table
+        self.parent_table.version_schema = self.option('table_schema') or \
+            self.parent_table.schema
+
     def option(self, name):
         try:
             return self.manager.option(self.model, name)
@@ -150,5 +154,6 @@ class TableBuilder(object):
             extends.name if extends is not None else self.table_name,
             self.parent_table.metadata,
             *columns,
-            extend_existing=extends is not None
+            extend_existing=extends is not None,
+            schema=self.parent_table.version_schema
         )

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -133,9 +133,9 @@ def version_table(table):
 
     :param table: SQLAlchemy Table object
     """
-    if table.metadata.schema:
+    if table.version_schema:
         return table.metadata.tables[
-            table.metadata.schema + '.' + table.name + '_version'
+            table.version_schema + '.' + table.name + '_version'
         ]
     else:
         return table.metadata.tables[

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -3,7 +3,15 @@ import sqlalchemy as sa
 from six import PY3
 from pytest import mark
 from sqlalchemy.ext.declarative import declarative_base
-from tests import TestCase
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy_continuum import (
+    ClassNotVersioned,
+    version_class,
+    make_versioned,
+    versioning_manager,
+)
+from tests import TestCase, get_driver_name, get_dns_from_driver
 
 
 @mark.skipif("os.environ.get('DB') == 'sqlite'")
@@ -58,6 +66,111 @@ class TestCustomSchema(TestCase):
     def create_tables(self):
         self.connection.execute('DROP SCHEMA IF EXISTS continuum')
         self.connection.execute('CREATE SCHEMA continuum')
+        TestCase.create_tables(self)
+
+    def test_version_relations(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        self.session.add(article)
+        self.session.commit()
+        assert article.versions[0].tags == []
+
+
+@mark.skipif("os.environ.get('DB') == 'sqlite'")
+class TestCustomVersionSchema(TestCase):
+    def setup_method(self, method):
+        self.Model = declarative_base(metadata=sa.MetaData(schema='continuum'))
+
+        options = self.options
+        options['table_schema'] = 'continuum_versions'
+        make_versioned(options=options)
+
+        driver = os.environ.get('DB', 'sqlite')
+        self.driver = get_driver_name(driver)
+        versioning_manager.plugins = self.plugins
+        versioning_manager.transaction_cls = self.transaction_cls
+        versioning_manager.user_cls = self.user_cls
+
+        self.engine = create_engine(get_dns_from_driver(self.driver))
+        # self.engine.echo = True
+        self.create_models()
+
+        sa.orm.configure_mappers()
+
+        self.connection = self.engine.connect()
+
+        if hasattr(self, 'Article'):
+            try:
+                self.ArticleVersion = version_class(self.Article)
+            except ClassNotVersioned:
+                pass
+        if hasattr(self, 'Tag'):
+            try:
+                self.TagVersion = version_class(self.Tag)
+            except ClassNotVersioned:
+                pass
+        self.create_tables()
+
+        Session = sessionmaker(bind=self.connection)
+        self.session = Session(autoflush=False)
+        if driver == 'postgres-native':
+            self.session.execute('CREATE EXTENSION IF NOT EXISTS hstore')
+
+    def teardown_method(self, method):
+        super(TestCustomVersionSchema, self).teardown_method(method)
+        versioning_manager.options['table_schema'] = None
+
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = 'article'
+            __versioned__ = {
+                'base_classes': (self.Model, )
+            }
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+
+        article_tag = sa.Table(
+            'article_tag',
+            self.Model.metadata,
+            sa.Column(
+                'article_id',
+                sa.Integer,
+                sa.ForeignKey('article.id', ondelete='CASCADE'),
+                primary_key=True,
+            ),
+            sa.Column(
+                'tag_id',
+                sa.Integer,
+                sa.ForeignKey('tag.id', ondelete='CASCADE'),
+                primary_key=True
+            )
+        )
+
+        class Tag(self.Model):
+            __tablename__ = 'tag'
+            __versioned__ = {
+                'base_classes': (self.Model, )
+            }
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+
+        Tag.articles = sa.orm.relationship(
+            Article,
+            secondary=article_tag,
+            backref='tags'
+        )
+
+        self.Article = Article
+        self.Tag = Tag
+
+    def create_tables(self):
+        self.connection.execute('DROP SCHEMA IF EXISTS continuum')
+        self.connection.execute('CREATE SCHEMA continuum')
+        self.connection.execute('DROP SCHEMA IF EXISTS continuum_versions')
+        self.connection.execute('CREATE SCHEMA continuum_versions')
         TestCase.create_tables(self)
 
     def test_version_relations(self):


### PR DESCRIPTION
Add new option in VersionManager that will tell TableBuilder if it should use
the same schema or the one specified as option for the versioning table.

This PR is related to issues 31 and 96.

Alembic users should do some extra work on their env.py file. In there,
context.configure must receive two new options, include_schemas and
include_object. Include schema is a boolean and must be set to True. Include
objects is a function that will filter the schemas in were we can work. This is
required because alembic won't recognize versions tables if include_schemas is
not set.

These options must be set in both run_migrations_offline and
run_migrations_online.

ex:

def include_object(obj, name, type_, refleccted, compare_to):
    url = config.get_main_option("sqlalchemy.url")
    schema = os.path.split(url)[1]
    if type_ == 'table':
        tbl = obj
    elif hasattr(obj, 'table'):
        tbl = obj.table
    else:
        return False
    return not tbl.schema or (tbl.schema and tbl.schema.startswith(schema))