### PR TITLE
Memory leaks with UnitOfWork instances

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -356,6 +356,7 @@ class VersioningManager(object):
         if conn in self.units_of_work:
             uow = self.units_of_work[conn]
             uow.reset(session)
+            del self.units_of_work[conn]
 
     def append_association_operation(self, conn, table_name, params, op):
         """

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -145,6 +145,8 @@ class VersioningManager(object):
         # as UnitOfWork objects.
         self.units_of_work = {}
 
+        self.session_connection_map = {}
+
         self.metadata = None
 
     def create_transaction_model(self):
@@ -305,6 +307,8 @@ class VersioningManager(object):
         :param session: SQLAlchemy session object
         """
         conn = session.connection()
+        if conn not in self.session_connection_map.values():
+            self.session_connection_map[session] = conn
 
         if conn in self.units_of_work:
             return self.units_of_work[conn]
@@ -352,7 +356,7 @@ class VersioningManager(object):
         """
         if session.transaction.nested:
             return
-        conn = session.bind
+        conn = self.session_connection_map.pop(session, None)
         if conn in self.units_of_work:
             uow = self.units_of_work[conn]
             uow.reset(session)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -121,6 +121,9 @@ class TestCase(object):
         self.Model.metadata.drop_all(self.connection)
 
     def teardown_method(self, method):
+        self.session.rollback()
+        uow_leaks = versioning_manager.units_of_work
+
         remove_versioning()
         QueryPool.queries = []
         versioning_manager.reset()
@@ -130,6 +133,8 @@ class TestCase(object):
         self.drop_tables()
         self.engine.dispose()
         self.connection.close()
+
+        assert not uow_leaks
 
     def create_models(self):
         class Article(self.Model):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -123,6 +123,7 @@ class TestCase(object):
     def teardown_method(self, method):
         self.session.rollback()
         uow_leaks = versioning_manager.units_of_work
+        session_map_leaks = versioning_manager.session_connection_map
 
         remove_versioning()
         QueryPool.queries = []
@@ -135,6 +136,7 @@ class TestCase(object):
         self.connection.close()
 
         assert not uow_leaks
+        assert not session_map_leaks
 
     def create_models(self):
         class Article(self.Model):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -24,6 +24,13 @@ class TestSessions(TestCase):
             article.versions[-1].transaction_id
         )
 
+    def test_connection_binded_to_engine(self):
+        self.session2 = Session(bind=self.engine)
+        article = self.Article(name=u'Session1 article')
+        self.session2.add(article)
+        self.session2.commit()
+        assert article.versions[-1].transaction_id
+
     def test_manual_transaction_creation(self):
         uow = versioning_manager.unit_of_work(self.session)
         transaction = uow.create_transaction(self.session)


### PR DESCRIPTION
Related to issue #131.

Fixes memory leaks related to `unit_of_works` dictionary. I added memory leak checks to test teardown step instead of separate test to make sure that my changes don't leak memory in any known use case.