### PR TITLE
Build a unit of work if one cannot be found

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -372,10 +372,11 @@ class VersioningManager(object):
             .insert()
             .values(params)
         )
-        try:
+        if conn in self.units_of_work:
             uow = self.units_of_work[conn]
-        except KeyError:
-            uow = self.units_of_work[conn.engine]
+        else:
+            uow = self.uow_class(self)
+            self.units_of_work[conn] = uow
         uow.pending_statements.append(stmt)
 
     def track_association_operations(


### PR DESCRIPTION
I'm trying to use association tables and I'm getting KeyError exceptions. This fixes my issue, I'm not sure why the existing tests didn't expose this issue.