### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ In order to make your models versioned you need two things:
 Resources
 ---------
 
-- `Documentation <http://sqlalchemy-continuum.readthedocs.org/>`_
+- `Documentation <https://sqlalchemy-continuum.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/kvesteri/sqlalchemy-continuum/issues>`_
 - `Code <http://github.com/kvesteri/sqlalchemy-continuum/>`_
 

--- a/sqlalchemy_continuum/plugins/activity.py
+++ b/sqlalchemy_continuum/plugins/activity.py
@@ -186,7 +186,7 @@ target is the given article.
 .. _activity stream specification:
     http://www.activitystrea.ms
 .. _generic relationships:
-    http://sqlalchemy-utils.readthedocs.org/en/latest/generic_relationship.html
+    https://sqlalchemy-utils.readthedocs.io/en/latest/generic_relationship.html
 """
 
 import sqlalchemy as sa


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.