### PR TITLE
Fix for when new value is a boolean and was changed to false

### DIFF
--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -410,7 +410,7 @@ def changeset(obj):
                 old_value = history.deleted[0] if history.deleted else None
                 new_value = history.added[0] if history.added else None
 
-                if new_value:
+                if new_value is not None:
                     data[prop.key] = [new_value, old_value]
     return data
 


### PR DESCRIPTION
If a value in the database is a boolean type and is changed from True -> False, the changeset shows as empty instead of showing True -> False. The error is from `new_value` being False and not passing the condition to add it to the changeset diff dict.
