### PR TITLE
Fix `changeset` method for multi-flush transactions

### DIFF
--- a/sqlalchemy_continuum/version.py
+++ b/sqlalchemy_continuum/version.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+
 from .reverter import Reverter
 from .utils import get_versioning_manager, is_internal_column, parent_class
 
@@ -49,9 +50,6 @@ class VersionClassBase(object):
         and second list value as the new value.
         """
         previous_version = self.previous
-        if not previous_version and self.operation_type != 0:
-            return {}
-
         data = {}
 
         for key in sa.inspect(self.__class__).columns.keys():

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -55,7 +55,11 @@ class ChangeSetTestCase(ChangeSetBaseTestCase):
             ''' % (self.transaction_column_name, tx_log.id)
         )
 
-        assert self.session.query(self.ArticleVersion).first().changeset == {}
+        assert self.session.query(self.ArticleVersion).first().changeset == {
+            'content': [None, 'some content'],
+            'id': [None, 1],
+            'name': [None, 'something']
+        }
 
 
 class TestChangeSetWithValidityStrategy(ChangeSetTestCase):
@@ -71,7 +75,7 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
         class Article(self.Model):
             __tablename__ = 'article'
             __versioned__ = {
-                'base_classes': (self.Model, )
+                'base_classes': (self.Model,)
             }
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -82,7 +86,7 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
         class Tag(self.Model):
             __tablename__ = 'tag'
             __versioned__ = {
-                'base_classes': (self.Model, )
+                'base_classes': (self.Model,)
             }
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -92,8 +96,8 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
 
         Article.tag_count = sa.orm.column_property(
             sa.select([sa.func.count(Tag.id)])
-            .where(Tag.article_id == Article.id)
-            .correlate_except(Tag)
+                .where(Tag.article_id == Article.id)
+                .correlate_except(Tag)
         )
 
         self.Article = Article


### PR DESCRIPTION
When in the same transaction you create object, flush, update object and commit transaction, Continuum will first flush `insert` version, but later it will update it to be `update` (happening here: https://github.com/kvesteri/sqlalchemy-continuum/blob/master/sqlalchemy_continuum/unit_of_work.py#L168)

This causes `changeset` to return empty dict for such changes, which is incorrect. I can see two solutions:
1. Change behaviour of `changeset` to not ignore such versions
2. Change behaviour of `process_operation` to not change `insert` into `update` (explored in #79)

This PR changes behaviour of `changeset` method to not ignore changes on update versions without previous versions.

This fixes #141.
