### PR TITLE
FlaskPlugin: use `get_id()` instead of `id` attr

### DIFF
--- a/sqlalchemy_continuum/plugins/flask.py
+++ b/sqlalchemy_continuum/plugins/flask.py
@@ -36,7 +36,7 @@ def fetch_current_user_id():
     if _app_ctx_stack.top is None or _request_ctx_stack.top is None:
         return
     try:
-        return current_user.id
+        return current_user.get_id()
     except AttributeError:
         return
 

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Flask, url_for
-from flask_login import LoginManager
+from flask_login import LoginManager, UserMixin
 from flask_sqlalchemy import SQLAlchemy, _SessionSignalEvents
 from flexmock import flexmock
 
@@ -76,7 +76,7 @@ class TestFlaskPlugin(TestCase):
     def create_models(self):
         TestCase.create_models(self)
 
-        class User(self.Model):
+        class User(self.Model, UserMixin):
             __tablename__ = 'user'
             __versioned__ = {
                 'base_classes': (self.Model, )


### PR DESCRIPTION
Following Flask-Login documentation we should use current_user.get_id()
instead of current_user.id.  (closes #149)
https://flask-login.readthedocs.io/en/latest/#your-user-class

@kvesteri WDYT?