### PR TITLE
Fix remote_addr for audits

### DIFF
--- a/sqlalchemy_continuum/plugins/flask.py
+++ b/sqlalchemy_continuum/plugins/flask.py
@@ -45,7 +45,7 @@ def fetch_remote_addr():
     # Return None if we are outside of request context.
     if _app_ctx_stack.top is None or _request_ctx_stack.top is None:
         return
-    return request.remote_addr
+    return request.headers.get('X-Forwarded-For', None)
 
 
 class FlaskPlugin(Plugin):

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -150,5 +150,6 @@ class TableBuilder(object):
             extends.name if extends is not None else self.table_name,
             self.parent_table.metadata,
             *columns,
-            extend_existing=extends is not None
+            extend_existing=extends is not None,
+            schema=self.option('table_schema') or self.parent_table.schema
         )


### PR DESCRIPTION
Description
-----------
Our audit tables use the flask plugin to automatically track
request `remote_addr`, the IP address where the change is being
made. The X-Forwarded-For request header gives us the client IP,
not the IP of the Aptible load balancer.

Related JIRA Issues
-------------------
SPARK-274

Related Pull Requests
---------------------

Migrations
----------

Extra Deployment Steps
----------------------

Testing Steps
-------------
* check audit log remote_addr