### PR TITLE
Skip sqlalchemy-i18n tests when driver is sqlite

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ from copy import copy
 import inspect
 import itertools as it
 import os
+import pytest
 import warnings
 import sqlalchemy as sa
 from sqlalchemy import create_engine
@@ -21,6 +22,9 @@ from sqlalchemy_continuum.plugins import (
 )
 
 warnings.simplefilter('error', sa.exc.SAWarning)
+
+
+pytest_skipif_sqlite = pytest.mark.skipif(os.environ.get('DB', 'sqlite') == 'sqlite')
 
 
 class QueryPool(object):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -2,13 +2,14 @@ import sqlalchemy as sa
 from sqlalchemy_continuum import versioning_manager
 from sqlalchemy_i18n import Translatable, make_translatable, translation_base
 from sqlalchemy_utils import i18n
-from . import TestCase
+from . import TestCase, pytest_skipif_sqlite
 
 
 i18n.get_locale = lambda: 'en'
 make_translatable()
 
 
+@pytest_skipif_sqlite(reason='SQLite does not support autoincrement for composite primary keys')
 class TestVersioningWithI18nExtension(TestCase):
     def create_models(self):
         class Versioned(self.Model):


### PR DESCRIPTION
SQLite does not support autoincrement for composite primary keys which is required for sqlalchemy-i18n