### PR TITLE
Add name customization option for the transaction table

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -1,5 +1,6 @@
 import re
 from functools import wraps
+import warnings
 
 import sqlalchemy as sa
 from sqlalchemy.orm import object_session
@@ -88,13 +89,23 @@ class VersioningManager(object):
             'end_transaction_column_name': 'end_transaction_id',
             'operation_type_column_name': 'operation_type',
             'strategy': 'validity',
-            'use_module_name': False
+            'use_module_name': False,
+            'transaction_table_name': 'transaction'
         }
         if plugins is None:
             self.plugins = []
         else:
             self.plugins = plugins
         self.options.update(options)
+
+        if (self.options['native_versioning']
+            and self.options['transaction_table_name'] != 'transaction'
+        ):
+            self.options['transaction_table_name'] = 'transaction'
+            warnings.warn(
+                'custom name for transaction table is not supported'
+                'with native versioning'
+            )
 
     @property
     def plugins(self):

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -116,7 +116,7 @@ class TransactionFactory(ModelFactory):
             manager.declarative_base,
             TransactionBase
         ):
-            __tablename__ = 'transaction'
+            __tablename__ = manager.options['transaction_table_name']
             __versioning_manager__ = manager
 
             id = sa.Column(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -62,6 +62,7 @@ class TestCase(object):
     versioning_strategy = 'subquery'
     transaction_column_name = 'transaction_id'
     end_transaction_column_name = 'end_transaction_id'
+    transaction_table_name = 'transaction'
     composite_pk = False
     plugins = [TransactionChangesPlugin(), TransactionMetaPlugin()]
     transaction_cls = TransactionFactory()
@@ -77,6 +78,7 @@ class TestCase(object):
             'strategy': self.versioning_strategy,
             'transaction_column_name': self.transaction_column_name,
             'end_transaction_column_name': self.end_transaction_column_name,
+            'transaction_table_name': self.transaction_table_name,
         }
 
     def setup_method(self, method):


### PR DESCRIPTION
Some minor changes will allow the customization of the `__tablename__` attribute for the default `Transcation` class through `manager.options`. This could be necessary if some kind of namespacing should take place in a shared database environment.