### PR TITLE
Fix possible random subclass retrival on closest_matching_table.

### DIFF
--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -1,4 +1,5 @@
 from copy import copy
+from inspect import getmro
 
 import sqlalchemy as sa
 from sqlalchemy_utils.functions import get_declarative_base
@@ -65,9 +66,10 @@ class Builder(object):
         """
         if model in self.manager.tables:
             return self.manager.tables[model]
-        for cls in self.manager.tables:
-            if issubclass(model, cls):
-                return self.manager.tables[cls]
+        subclasses = [cls for cls in self.manager.tables if issubclass(model, cls)]
+        ordered_subclasses = [cls for cls in getmro(model) if cls in subclasses]
+        return self.manager.tables[ordered_subclasses[0]] if ordered_subclasses else None
+
 
     def build_models(self):
         """

--- a/tests/inheritance/test_multi_level_inheritance.py
+++ b/tests/inheritance/test_multi_level_inheritance.py
@@ -1,0 +1,47 @@
+import sqlalchemy as sa
+from sqlalchemy_continuum import version_class
+from tests import TestCase
+
+
+class TestCommonBaseClass(TestCase):
+    def create_models(self):
+        class BaseModel(self.Model):
+            __tablename__ = 'base_model'
+            __versioned__ = {}
+
+            id = sa.Column(sa.Integer, primary_key=True)
+            discriminator = sa.Column(sa.String(50), index=True)
+
+            __mapper_args__ = {
+                'polymorphic_on': discriminator,
+                'polymorphic_identity': 'product'
+            }
+
+        class FirstLevel(BaseModel):
+            __tablename__ = 'first_level'
+
+            id = sa.Column(sa.Integer, sa.ForeignKey('base_model.id'), primary_key=True)
+
+            __mapper_args__ = {
+                'polymorphic_identity': 'first_level'
+            }
+
+        class SecondLevel(FirstLevel):
+            __mapper_args__ = {
+                'polymorphic_identity': 'second_level'
+            }
+
+        self.BaseModel = BaseModel
+        self.FirstLevel = FirstLevel
+        self.SecondLevel = SecondLevel
+
+    def test_sa_inheritance_with_no_distinct_table_has_right_translation_class(self):
+        class_ = version_class(self.BaseModel)
+        assert class_.__name__ == 'BaseModelVersion'
+        assert class_.__table__.name == 'base_model_version'
+        class_ = version_class(self.FirstLevel)
+        assert class_.__name__ == 'FirstLevelVersion'
+        assert class_.__table__.name == 'first_level_version'
+        class_ = version_class(self.SecondLevel)
+        assert class_.__name__ == 'SecondLevelVersion'
+        assert class_.__table__.name == 'first_level_version'


### PR DESCRIPTION
If there is no exact match for a given model the function would
return the first parent class it find on manager.tables.
If it happens to be a subclass of more than one table on
manager.tables it may return distinct tables between executions
due to the fact that the manager.tables list been built in a
different order.

This change makes it return the first hierarchical class included
on manager.tables.