### PR TITLE
Fix Sequence declaration

### DIFF
--- a/sqlalchemy_continuum/plugins/activity.py
+++ b/sqlalchemy_continuum/plugins/activity.py
@@ -199,13 +199,6 @@ from ..utils import version_class, version_obj
 
 
 class ActivityBase(object):
-    id = sa.Column(
-        sa.BigInteger,
-        sa.schema.Sequence('activity_id_seq'),
-        primary_key=True,
-        autoincrement=True
-    )
-
     verb = sa.Column(sa.Unicode(255))
 
     @hybrid_property
@@ -226,6 +219,18 @@ class ActivityFactory(ModelFactory):
         ):
             __tablename__ = 'activity'
             manager = self
+
+            id_seq = sa.schema.Sequence(
+                'activity_id_seq',
+                metadata=manager.declarative_base.metadata
+            )
+
+            id = sa.Column(
+                sa.BigInteger,
+                server_default=id_seq.next_value(),
+                primary_key=True,
+                autoincrement=True
+            )
 
             transaction_id = sa.Column(
                 sa.BigInteger,

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -119,9 +119,14 @@ class TransactionFactory(ModelFactory):
             __tablename__ = 'transaction'
             __versioning_manager__ = manager
 
+            id_seq = sa.schema.Sequence(
+                'transaction_id_seq',
+                metadata=manager.declarative_base.metadata
+            )
+
             id = sa.Column(
                 sa.types.BigInteger,
-                sa.schema.Sequence('transaction_id_seq'),
+                server_default=id_seq.next_value(),
                 primary_key=True,
                 autoincrement=True
             )


### PR DESCRIPTION
I was struggling to fix an error when dropping the entire database structure (in Postgres) of my Flask project (`db.metadata.drop_all(db.engine)`) that started to pop right after I've implemented this library:

```
sqlalchemy.exc.InternalError: (psycopg2.InternalError) cannot drop sequence table_name_id_seq because other objects depend on it
```

The problem is that commit 0bb36e02 started using the Sequence on the ID columns.

[According to SQLAlchemy documentation](http://docs.sqlalchemy.org/en/latest/core/defaults.html#associating-a-sequence-with-the-metadata), any Sequence should be bound to a metadata in order to work correctly.

In addition to it, [another post](http://www.net153.net/blog/20161028-23-04.html) also says how to get rid of errors when dropping/creating all the database schema when using Sequence.

Hope to have helped anyone having this issue