### PR TITLE
Reraise original exception instead of a new one

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -32,7 +32,7 @@ def tracked_operation(func):
                         uow = self.unit_of_work(session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
-                    raise KeyError
+                    raise
         return func(self, uow, target)
     return wrapper
 
@@ -400,7 +400,7 @@ class VersioningManager(object):
                         uow = self.unit_of_work(conn.session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
-                    raise KeyError
+                    raise
         uow.pending_statements.append(stmt)
 
     def track_cloned_connections(self, c, opt):


### PR DESCRIPTION
Raising a new `KeyError` means you lose the original stacktrace, which
is going to be more useful since it'll contain more information about
the relevant context for this error.