### PR TITLE
Fix ResourceClosedErrors from connections leaking when using an external transaction

### DIFF
--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -72,6 +72,12 @@ def make_versioned(
 
     sa.event.listen(
         sa.engine.Engine,
+        'rollback',
+        manager.clear_connection
+    )
+
+    sa.event.listen(
+        sa.engine.Engine,
         'set_connection_execution_options',
         manager.track_cloned_connections
     )
@@ -101,6 +107,12 @@ def remove_versioning(
         sa.engine.Engine,
         'before_cursor_execute',
         manager.track_association_operations
+    )
+
+    sa.event.remove(
+        sa.engine.Engine,
+        'rollback',
+        manager.clear_connection
     )
 
     sa.event.remove(

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -28,7 +28,7 @@ def tracked_operation(func):
                 uow = self.units_of_work[conn.engine]
             except KeyError:
                 for connection in self.units_of_work.keys():
-                    if connection.connection is conn.connection:
+                    if not connection.closed and connection.connection is conn.connection:
                         uow = self.unit_of_work(session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
@@ -374,7 +374,7 @@ class VersioningManager(object):
             del self.units_of_work[conn]
 
         for connection in dict(self.units_of_work).keys():
-            if conn.connection is connection.connection:
+            if connection.closed or conn.connection is connection.connection:
                 uow = self.units_of_work[connection]
                 uow.reset(session)
                 del self.units_of_work[connection]
@@ -396,7 +396,7 @@ class VersioningManager(object):
                 uow = self.units_of_work[conn.engine]
             except KeyError:
                 for connection in self.units_of_work.keys():
-                    if connection.connection is conn.connection:
+                    if not connection.closed and connection.connection is conn.connection:
                         uow = self.unit_of_work(conn.session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
@@ -409,7 +409,7 @@ class VersioningManager(object):
         """
         if c not in self.units_of_work.keys():
             for connection, uow in dict(self.units_of_work).items():
-                if connection.connection is c.connection:  # ConnectionFairy is the same - this is a clone
+                if not connection.closed and connection.connection is c.connection:  # ConnectionFairy is the same - this is a clone
                     self.units_of_work[c] = uow
 
     def track_association_operations(

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -379,6 +379,25 @@ class VersioningManager(object):
                 uow.reset(session)
                 del self.units_of_work[connection]
 
+    def clear_connection(self, conn):
+        if conn in self.units_of_work:
+            uow = self.units_of_work[conn]
+            uow.reset()
+            del self.units_of_work[conn]
+
+
+        for session, connection in dict(self.session_connection_map).items():
+            if connection is conn:
+                del self.session_connection_map[session]
+
+
+        for connection in dict(self.units_of_work).keys():
+            if connection.closed or conn.connection is connection.connection:
+                uow = self.units_of_work[connection]
+                uow.reset()
+                del self.units_of_work[connection]
+
+
     def append_association_operation(self, conn, table_name, params, op):
         """
         Append history association operation to pending_statements list.

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -52,3 +52,19 @@ class TestUnitOfWork(TestCase):
     def test_with_session_arg(self):
         uow = versioning_manager.unit_of_work(self.session)
         assert isinstance(uow, UnitOfWork)
+
+
+class TestExternalTransactionSession(TestCase):
+
+    def test_session_with_external_transaction(self):
+        conn = self.engine.connect()
+        t = conn.begin()
+        session = Session(bind=conn)
+
+        article = self.Article(name=u'My Session Article')
+        session.add(article)
+        session.flush()
+
+        session.close()
+        t.rollback()
+        conn.close()


### PR DESCRIPTION
This should fix #188. TestCase doesn't perfectly recreate the original issue but it should reveal the underlying problem which is connections being kept around even when they're closed.

Without the patch:

```
$ pytest tests/test_sessions.py -k TestExternalTransactionSession
======================================================== test session starts ========================================================
platform darwin -- Python 3.6.5, pytest-3.6.3, py-1.5.4, pluggy-0.6.0
collected 6 items / 5 deselected

tests/test_sessions.py .E                                                                                                     [100%]

============================================================== ERRORS ===============================================================
____________________ ERROR at teardown of TestExternalTransactionSession.test_session_with_external_transaction _____________________

self = <tests.test_sessions.TestExternalTransactionSession object at 0x10dbe2b70>
method = <bound method TestExternalTransactionSession.test_session_with_external_transaction of <tests.test_sessions.TestExternalTransactionSession object at 0x10dbe2b70>>

    def teardown_method(self, method):
        self.session.rollback()
        uow_leaks = versioning_manager.units_of_work
        session_map_leaks = versioning_manager.session_connection_map

        remove_versioning()
        QueryPool.queries = []
        versioning_manager.reset()

        self.session.close_all()
        self.session.expunge_all()
        self.drop_tables()
        self.engine.dispose()
        self.connection.close()

>       assert not uow_leaks
E       AssertionError

tests/__init__.py:138: AssertionError
========================================== 1 passed, 5 deselected, 1 error in 1.00 seconds ==========================================
```

With the patch:


```
$ pytest tests/test_sessions.py -k TestExternalTransactionSession
======================================================== test session starts ========================================================
platform darwin -- Python 3.6.5, pytest-3.6.3, py-1.5.4, pluggy-0.6.0
collected 6 items / 5 deselected

tests/test_sessions.py .                                                                                                      [100%]

============================================== 1 passed, 5 deselected in 1.21 seconds ===============================================
```