### PR TITLE
WIP: Removed non-table columns from the restore operation

### DIFF
--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -202,7 +202,11 @@ def versioned_column_properties(obj_or_class):
     cls = obj_or_class if isclass(obj_or_class) else obj_or_class.__class__
 
     mapper = sa.inspect(cls)
-    for key in mapper.columns.keys():
+    for key, column in mapper.columns.items():
+        # Ignores non table columns
+        if not isinstance(column, sa.Column):
+            continue
+
         if not manager.is_excluded_property(obj_or_class, key):
             yield getattr(mapper.attrs, key)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+
 from copy import copy
 import inspect
 import itertools as it
@@ -6,7 +7,7 @@ import warnings
 import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, column_property
 from sqlalchemy_continuum import (
     ClassNotVersioned,
     version_class,
@@ -147,6 +148,9 @@ class TestCase(object):
             name = sa.Column(sa.Unicode(255), nullable=False)
             content = sa.Column(sa.UnicodeText)
             description = sa.Column(sa.UnicodeText)
+
+            # Dynamic column cotaining all text content data
+            fulltext_content = column_property(name + content + description)
 
         class Tag(self.Model):
             __tablename__ = 'tag'


### PR DESCRIPTION
When a table contains a *sa.orm.column_property* the restore
operation crashes if the column is not on the ignore list.

This change filters out those invalid columns (non-table)
to remove the need for this declaration.

Fixes: https://github.com/kvesteri/sqlalchemy-continuum/issues/197