### PR TITLE
Fix sync trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ nosetests.xml
 
 # Unit test / coverage reports
 .cache
+
+# idea
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ nosetests.xml
 
 # idea
 .idea/
+
+# pyenv
+.python-version

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.9+geru.1 (2019-06-03)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Support for downgrades (only drop trigger) in native_versioning
+- Support for customized version tables in native_versioning
+- Simpler use of sync_trigger (with table model) in native_versioning
+
+
 1.3.9 (2019-03-19)
 ^^^^^^^^^^^^^^^^^^
 

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.9'
+__version__ = '1.3.9+geru.1'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
 
-from sqlalchemy_continuum import version_class
 from sqlalchemy_continuum.plugins import PropertyModTrackerPlugin
 
 
@@ -485,8 +484,10 @@ def sync_trigger(conn, table_model):
     except sa.exc.NoSuchTableError:
         return
 
+    from sqlalchemy_continuum import versioning_manager
+    version_pattern = versioning_manager.options['table_name']
     version_table = sa.Table(
-        version_class(parent_table),
+        version_pattern % table_model,
         meta,
         autoload=True,
         autoload_with=conn

--- a/tests/dialects/test_triggers.py
+++ b/tests/dialects/test_triggers.py
@@ -59,3 +59,12 @@ class TestTriggerSyncing(object):
             in QueryPool.queries[-2]
         )
         assert 'DROP FUNCTION ' in QueryPool.queries[-1]
+
+    def test_drop_triggers_using_sync(self):
+        self.connection.execute('DROP TABLE IF EXISTS article')
+        sync_trigger(self.connection, 'article')
+        assert (
+            'DROP TRIGGER IF EXISTS article_trigger ON "article"'
+            in QueryPool.queries[-3]
+        )
+        assert 'DROP FUNCTION ' in QueryPool.queries[-2]

--- a/tests/dialects/test_triggers.py
+++ b/tests/dialects/test_triggers.py
@@ -42,15 +42,15 @@ class TestTriggerSyncing(object):
         self.connection.close()
 
     def test_sync_triggers(self):
-        sync_trigger(self.connection, 'article_version')
+        sync_trigger(self.connection, 'article')
         assert (
             'DROP TRIGGER IF EXISTS article_trigger ON "article"'
-            in QueryPool.queries[-4]
+            in QueryPool.queries[3]
         )
-        assert 'DROP FUNCTION ' in QueryPool.queries[-3]
+        assert 'DROP FUNCTION ' in QueryPool.queries[4]
         assert 'CREATE OR REPLACE FUNCTION ' in QueryPool.queries[-2]
         assert 'CREATE TRIGGER ' in QueryPool.queries[-1]
-        sync_trigger(self.connection, 'article_version')
+        sync_trigger(self.connection, 'article')
 
     def test_drop_triggers(self):
         drop_trigger(self.connection, 'article')


### PR DESCRIPTION
Part of https://geruteam.atlassian.net/browse/CORE-1569

This implements an enhanced version of sync_trigger, which includes:
- Support for downgrades (only drop trigger) in native_versioning
- Support for customized version tables in native_versioning
- Simpler use of sync_trigger (with table model) in native_versioning

Also mitigates bug: https://github.com/kvesteri/sqlalchemy-continuum/issues/115