### PR TITLE
Add a link to the SQLAlchemy history_meta example

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,7 @@ Introduction
 Why?
 ^^^^
 
-SQLAlchemy already has a versioning extension. This extension however is very limited. It does not support versioning entire transactions.
+SQLAlchemy [already has a versioning extension](https://docs.sqlalchemy.org/en/13/orm/examples.html#module-examples.versioned_history). This extension however is very limited. It does not support versioning entire transactions.
 
 Hibernate for Java has Envers, which had nice features but lacks a nice API. Ruby on Rails has papertrail_, which has very nice API but lacks the efficiency and feature set of Envers.
 


### PR DESCRIPTION
I stumbled across this mention of an SQLAlchemy versioning extension a few times, and googling it up every time is embarassing. Did I get it right this time, after all?