### PR TITLE
Fix a link formatting from markdown to rst

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,7 @@ Introduction
 Why?
 ^^^^
 
-SQLAlchemy [already has a versioning extension](https://docs.sqlalchemy.org/en/13/orm/examples.html#module-examples.versioned_history). This extension however is very limited. It does not support versioning entire transactions.
+SQLAlchemy `already has a versioning extension <https://docs.sqlalchemy.org/en/13/orm/examples.html#module-examples.versioned_history>`_. This extension however is very limited. It does not support versioning entire transactions.
 
 Hibernate for Java has Envers, which had nice features but lacks a nice API. Ruby on Rails has papertrail_, which has very nice API but lacks the efficiency and feature set of Envers.
 


### PR DESCRIPTION
The previous commit was added through the github editor without looking at the preview.