### PR TITLE
#128 Update docs regarding `alembic-migrations`

### DIFF
--- a/docs/alembic.rst
+++ b/docs/alembic.rst
@@ -1,6 +1,11 @@
 Alembic migrations
 ==================
 
-Each time you make changes to database structure you should also change the associated history tables. When you make changes to your models SQLAlchemy-Continuum automatically alters the history model definitions, hence you can use `alembic revision --autogenerate` just like before. You just need to make sure `make_versioned` function gets called before alembic gathers all your models.
+Each time you make changes to database structure you should also change the associated history tables. When you make changes to your models SQLAlchemy-Continuum automatically alters the history model definitions, hence you can use `alembic revision --autogenerate` just like before. You just need to make sure `make_versioned` function gets called before alembic gathers all your models and `configure_mappers` is called afterwards.
 
 Pay close attention when dropping or moving data from parent tables and reflecting these changes to history tables.
+
+Troubleshooting
+###############
+
+If alembic didn't detect any changes or generates reversed migration (tries to remove `*_version` tables from database instead of creating), make sure that `configure_mappers` was called by alembic command.


### PR DESCRIPTION
`configure_mappers` is [invoked automatically](https://docs.sqlalchemy.org/en/13/orm/mapping_api.html?highlight=configure_mappers#sqlalchemy.orm.configure_mappers) when service is running:

> This function can be called any number of times, but in most cases is invoked automatically, the first time mappings are used, as well as whenever mappings are used and additional not-yet-configured mappers have been constructed.

That's why it's easy to forget about it and have problem with `alembic` migrations.

Me and other people: #128, #173 suffered from this problem.