### PR TITLE
Fix m2m Bug when an unrelated change is made to a model

### DIFF
--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -249,6 +249,7 @@ class RelationshipBuilder(object):
                 FROM article_tag_version as article_tag_version2
                 WHERE article_tag_version2.tag_id = article_tag_version.tag_id
                 AND article_tag_version2.tx_id <=5
+                AND article_tag_version2.article_id = 3
                 GROUP BY article_tag_version2.tag_id
                 HAVING
                     MAX(article_tag_version2.tx_id) =
@@ -260,6 +261,8 @@ class RelationshipBuilder(object):
         """
 
         tx_column = option(obj, 'transaction_column_name')
+        join_column = self.property.primaryjoin.right.name
+        object_join_column = self.property.primaryjoin.left.name
         reflector = VersionExpressionReflector(obj, self.property)
 
         association_table_alias = self.association_version_table.alias()
@@ -276,6 +279,7 @@ class RelationshipBuilder(object):
                 sa.and_(
                     association_table_alias.c[tx_column] <=
                     getattr(obj, tx_column),
+                    association_table_alias.c[join_column] == getattr(obj, object_join_column),
                     *[association_col ==
                       self.association_version_table.c[association_col.name]
                       for association_col

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -70,6 +70,33 @@ class ManyToManyRelationshipsTestCase(TestCase):
         self.session.commit()
         assert len(article.versions[0].tags) == 1
 
+    def test_unrelated_change(self):
+        tag1 = self.Tag(name=u'some tag')
+        tag2 = self.Tag(name=u'some tag2')
+
+        self.session.add(tag1)
+        self.session.add(tag2)
+        self.session.commit()
+
+        article1 = self.Article(name="Some article", )
+        article1.name = u'Some article'
+        article1.tags.append(tag1)
+
+        self.session.add(article1)
+        self.session.commit()
+
+        article2 = self.Article()
+        article2.name = u'Some article2'
+        article2.tags.append(tag1)
+
+        self.session.add(article2)
+        self.session.commit()
+
+        article1.name = u'Some other name'
+        self.session.commit()
+
+        assert len(article1.versions[1].tags) == 1
+
     def test_multi_insert(self):
         article = self.Article()
         article.name = u'Some article'


### PR DESCRIPTION
I believe I have discovered and patched a bug in the m2m versioning. When an unrelated change is made in certain circumstances, SQLAchemy-Continuum incorrectly reports that the relationship is empty on the version object representing that unrelated change.