### PR TITLE
Fix the login/logout helpers in the FlaskPlugin tests

### DIFF
--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -66,12 +66,12 @@ class TestFlaskPlugin(TestCase):
         :returns: the logged in user
         """
         with self.client.session_transaction() as s:
-            s['user_id'] = user.id
+            s['_user_id'] = user.id
         return user
 
     def logout(self, user=None):
         with self.client.session_transaction() as s:
-            s['user_id'] = None
+            s['_user_id'] = None
 
     def create_models(self):
         TestCase.create_models(self)
@@ -281,5 +281,3 @@ class TestFlaskPluginWithFlaskSQLAlchemyExtension(object):
         uow = versioning_manager.unit_of_work(self.db.session)
         transaction = uow.create_transaction(self.db.session)
         assert transaction.id
-
-


### PR DESCRIPTION
Tests were failing since the Flask-Login extension has prefixed internal variable names with an underscore:

https://github.com/maxcountryman/flask-login/pull/470