### PR TITLE
Fix #245: create column aliases in the version table

### DIFF
--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -261,6 +261,7 @@ class ModelBuilder(object):
             name = '%sVersion' % (self.model.__name__,)
         return type(name, self.base_classes(), args)
 
+
     def __call__(self, table, tx_class):
         """
         Build history model and relationships to parent model, transaction

--- a/tests/inheritance/test_single_table_inheritance.py
+++ b/tests/inheritance/test_single_table_inheritance.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy_continuum import versioning_manager, version_class
 from tests import TestCase, create_test_cases
 
@@ -24,6 +25,10 @@ class SingleTableInheritanceTestCase(TestCase):
         class Article(TextItem):
             __mapper_args__ = {'polymorphic_identity': u'article'}
             name = sa.Column(sa.Unicode(255))
+
+            @sa.ext.declarative.declared_attr
+            def status(cls):
+                return sa.Column("_status", sa.Unicode(255))
 
         class BlogPost(TextItem):
             __mapper_args__ = {'polymorphic_identity': u'blog_post'}
@@ -78,6 +83,9 @@ class SingleTableInheritanceTestCase(TestCase):
         ).first()
         assert transaction.entity_names == [u'Article']
         assert transaction.changed_entities
+
+    def test_declared_attr_inheritance(self):
+        assert self.ArticleVersion.status
 
 
 create_test_cases(SingleTableInheritanceTestCase)


### PR DESCRIPTION
This is more of a proof of concept, as I'm not sure about several things:

1. Is `ModelBuilder` a good place to create "aliases"?
2. What would be a correct SQLAlchemy terminology for this? 
3. #245 is an issue I had with STI, but it might not be limited just to that. What would be a better place for putting the tests? 