### PR TITLE
Setup.py won't pull in SQLAlchemy >= 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'SQLAlchemy>=1.0.8, <1.4.0',
+        'SQLAlchemy>=1.0.8 <1.4.0',
         'SQLAlchemy-Utils>=0.30.12'
     ],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'SQLAlchemy>=1.0.8',
+        'SQLAlchemy>=1.0.8, <1.4.0',
         'SQLAlchemy-Utils>=0.30.12'
     ],
     extras_require=extras_require,


### PR DESCRIPTION
Barring making this module compatible with SQLAlchemy 1.4, lets at least specify that we're not compatible.