### PR TITLE
fix issue 85 "TransactionBase.changed_entities fails without TransactionChanges plugin"

### DIFF
--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -23,6 +23,10 @@ def compile_big_integer(element, compiler, **kw):
     return 'INTEGER'
 
 
+class NoChangesColumn(Exception):
+    pass
+
+
 class TransactionBase(object):
     issued_at = sa.Column(sa.DateTime, default=datetime.utcnow)
 
@@ -30,8 +34,13 @@ class TransactionBase(object):
     def entity_names(self):
         """
         Return a list of entity names that changed during this transaction.
+        Raises a NoChangesColumn exception if the 'changes' column does
+        not exist, most likely because TransactionChangesPlugin is not enabled.
         """
-        return [changes.entity_name for changes in self.changes]
+        if 'changes' in self.__table__.columns:
+          return [changes.entity_name for changes in self.changes]
+        else:
+          raise NoChangesColumn()
 
     @property
     def changed_entities(self):
@@ -48,8 +57,11 @@ class TransactionBase(object):
         session = sa.orm.object_session(self)
 
         for class_, version_class in tuples:
-            if class_.__name__ not in self.entity_names:
-                continue
+            try:
+                if class_.__name__ not in self.entity_names:
+                    continue
+            except NoChangesColumn:
+                pass
 
             tx_column = manager.option(class_, 'transaction_column_name')
 

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -23,7 +23,7 @@ def compile_big_integer(element, compiler, **kw):
     return 'INTEGER'
 
 
-class NoChangesColumn(Exception):
+class NoChangesAttribute(Exception):
     pass
 
 
@@ -34,13 +34,13 @@ class TransactionBase(object):
     def entity_names(self):
         """
         Return a list of entity names that changed during this transaction.
-        Raises a NoChangesColumn exception if the 'changes' column does
+        Raises a NoChangesAttribute exception if the 'changes' column does
         not exist, most likely because TransactionChangesPlugin is not enabled.
         """
         if hasattr(self, 'changes'):
           return [changes.entity_name for changes in self.changes]
         else:
-          raise NoChangesColumn()
+          raise NoChangesAttribute()
 
     @property
     def changed_entities(self):
@@ -60,7 +60,7 @@ class TransactionBase(object):
             try:
                 if class_.__name__ not in self.entity_names:
                     continue
-            except NoChangesColumn:
+            except NoChangesAttribute:
                 pass
 
             tx_column = manager.option(class_, 'transaction_column_name')

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -37,7 +37,7 @@ class TransactionBase(object):
         Raises a NoChangesColumn exception if the 'changes' column does
         not exist, most likely because TransactionChangesPlugin is not enabled.
         """
-        if 'changes' in self.__table__.columns:
+        if hasattr(self, 'changes'):
           return [changes.entity_name for changes in self.changes]
         else:
           raise NoChangesColumn()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -2,6 +2,8 @@ import sqlalchemy as sa
 from sqlalchemy_continuum import versioning_manager
 from tests import TestCase
 from pytest import mark
+from sqlalchemy_continuum.plugins import TransactionMetaPlugin
+
 
 
 class TestTransaction(TestCase):
@@ -37,6 +39,19 @@ class TestTransaction(TestCase):
             ) ==
             repr(transaction)
         )
+
+    def test_changed_entities(self):
+        article_v0 = self.article.versions[0]
+        transaction = article_v0.transaction
+        assert transaction.changed_entities == {
+            self.ArticleVersion: [article_v0],
+            self.TagVersion: [self.article.tags[0].versions[0]],
+        }
+
+
+# Check that the tests pass without TransactionChangesPlugin
+class TestTransactionWithoutChangesPlugin(TestTransaction):
+    plugins = [TransactionMetaPlugin()]
 
 
 class TestAssigningUserClass(TestCase):


### PR DESCRIPTION
add test that reproduces issue 85 "TransactionBase.changed_entities fails without TransactionChanges plugin" and fix that has Transaction.entity_names raise a NoChangesColumn instead of AttributeError.