### PR TITLE
fix for unit_of_work.py:263: SAWarning: implicitly coercing SELECT object to scalar subquery

### DIFF
--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -252,7 +252,7 @@ class UnitOfWork(object):
                     parent,
                     version_obj,
                     alias=sa.orm.aliased(class_.__table__)
-                )
+                ).scalar_subquery()
                 query = (
                     session.query(class_.__table__)
                     .filter(

--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -252,7 +252,12 @@ class UnitOfWork(object):
                     parent,
                     version_obj,
                     alias=sa.orm.aliased(class_.__table__)
-                ).scalar_subquery()
+                )
+                try:
+                    subquery = subquery.scalar_subquery()
+                except AttributeError:  # SQLAlchemy < 1.4
+                    subquery = subquery.as_scalar()
+
                 query = (
                     session.query(class_.__table__)
                     .filter(


### PR DESCRIPTION
Tested by running `DB=sqlite py.test tests` with `pip install SQLAlchemy==1.4.31`
With master: 653 passed, 99 skipped, 4909 warnings in 65.90s (0:01:05)
With this change: 653 passed, 99 skipped, 4695 warnings in 64.93s (0:01:04)
and then again with `pip install SQLAlchemy==1.3.24`
655 passed, 97 skipped, 657 warnings in 64.88s (0:01:04)