### PR TITLE
(ISSUE-272) Allow to disable mod plugin in sync_triggers

### DIFF
--- a/docs/native_versioning.rst
+++ b/docs/native_versioning.rst
@@ -31,7 +31,7 @@ When making schema migrations (for example adding new columns to version tables)
 
     sync_trigger(conn, 'article_version')
 
-If you don't use `PropertyModTrackerPlugin`, then you need to disable it:
+If you don't use `PropertyModTrackerPlugin`, then you have to disable it:
 
 ::
 

--- a/docs/native_versioning.rst
+++ b/docs/native_versioning.rst
@@ -30,3 +30,9 @@ When making schema migrations (for example adding new columns to version tables)
 
 
     sync_trigger(conn, 'article_version')
+
+If you don't use `PropertyModTrackerPlugin`, then you need to disable it:
+
+::
+
+    sync_trigger(conn, 'article_version', use_property_mod_tracking=False)

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -456,7 +456,7 @@ def create_versioning_trigger_listeners(manager, cls):
     )
 
 
-def sync_trigger(conn, table_name):
+def sync_trigger(conn, table_name, **kwargs):
     """
     Synchronizes versioning trigger for given table with given connection.
 
@@ -468,6 +468,7 @@ def sync_trigger(conn, table_name):
 
     :param conn: SQLAlchemy connection object
     :param table_name: Name of the table to synchronize versioning trigger for
+    :params **kwargs: kwargs to pass to create_trigger
 
     .. versionadded: 1.1.0
     """
@@ -489,7 +490,7 @@ def sync_trigger(conn, table_name):
         set(c.name for c in version_table.c if not c.name.endswith('_mod'))
     )
     drop_trigger(conn, parent_table.name)
-    create_trigger(conn, table=parent_table, excluded_columns=excluded_columns)
+    create_trigger(conn, table=parent_table, excluded_columns=excluded_columns, **kwargs)
 
 
 def create_trigger(


### PR DESCRIPTION
The pg audit function was failing because it is built with `_mod` feature enabled by default.

There are a few ways to disable it, I had to copy/change sync_triggers, and I see other developers fork the repository. Neither of the solutions is good.

This PR allows passing create_triggers arguments as sync_triggers kwargs.

I don't see a good way to detect if the plugin is enabled in sync_triggers.