### PR TITLE
Fix for column.copy deprecation

### DIFF
--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -20,12 +20,9 @@ class ColumnReflector(object):
 
         :param column: SQLAlchemy Column object of parent table
         """
-        # Make a copy of the column so that it does not point to wrong
-        # table.
-        column_copy = column.copy()
-        # Remove unique constraints
+        # Make a copy of the column so that it does not point to wrong table.
+        column_copy = column._copy() if hasattr(column, '_copy') else column.copy()
         column_copy.unique = False
-        # Remove onupdate triggers
         column_copy.onupdate = None
         if column_copy.autoincrement:
             column_copy.autoincrement = False


### PR DESCRIPTION
Run the test setting `DB=sqlite`.
SQLAlchemy 1.4.39

Before: `659 passed, 99 skipped, 4745 warnings in 49.06s`

After: `659 passed, 99 skipped, 797 warnings in 46.61s`