### PR TITLE
Pin werkzeug to fix CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extras_require = {
     'flask-sqlalchemy': ['Flask-SQLAlchemy>=1.0'],
     'flexmock': ['flexmock>=0.9.7'],
     'i18n': ['SQLAlchemy-i18n>=0.8.4,!=1.1.0'],
+    'Werkzeug': ['Werkzeug==2.1.2']
 }
 
 


### PR DESCRIPTION
Pin werkzeug to 2.1.2 to enable compatibility with the latest flask-login.

This should remove the errors on CI.

Flask-login issue here: [https://github.com/maxcountryman/flask-login/issues/686](https://github.com/maxcountryman/flask-login/issues/686)