### PR TITLE
Fix close_all deprecation warning

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -6,7 +6,7 @@ from time import time
 import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, close_all_sessions
 from sqlalchemy_continuum import (
     make_versioned,
     versioning_manager,
@@ -106,7 +106,7 @@ def test_versioning(
     remove_versioning()
     versioning_manager.reset()
 
-    session.close_all()
+    close_all_sessions()
     session.expunge_all()
     Model.metadata.drop_all(connection)
     engine.dispose()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ import warnings
 import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, column_property
+from sqlalchemy.orm import sessionmaker, column_property, close_all_sessions
 from sqlalchemy_continuum import (
     ClassNotVersioned,
     version_class,
@@ -130,7 +130,7 @@ class TestCase(object):
         QueryPool.queries = []
         versioning_manager.reset()
 
-        self.session.close_all()
+        close_all_sessions()
         self.session.expunge_all()
         self.drop_tables()
         self.engine.dispose()

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -6,6 +6,7 @@ from flask_sqlalchemy import SQLAlchemy, _SessionSignalEvents
 from flexmock import flexmock
 
 import sqlalchemy as sa
+from sqlalchemy.orm import close_all_sessions
 from sqlalchemy_continuum import (
     make_versioned, remove_versioning, versioning_manager
 )
@@ -248,7 +249,7 @@ class TestFlaskPluginWithFlaskSQLAlchemyExtension(object):
         remove_versioning()
         self.db.session.remove()
         self.db.drop_all()
-        self.db.session.close_all()
+        close_all_sessions()
         self.db.engine.dispose()
         self.context.pop()
         self.context = None


### PR DESCRIPTION
`session.close_all()` has been deprecated in favour of `orm.close_all_sessions()`

After: `659 passed, 99 skipped, 4090 warnings`

Before: `659 passed, 99 skipped, 4745 warnings`