### PR TITLE
Fix #238: handling version_table from option method

### DIFF
--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -145,6 +145,7 @@ class TableBuilder(object):
         Builds version table.
         """
         self.parent_table.__versioning_manager__ = self.manager
+        self.parent_table.model = self.model
         columns = self.columns if extends is None else []
         self.manager.plugins.after_build_version_table_columns(self, columns)
         version_table = sa.schema.Table(
@@ -155,4 +156,5 @@ class TableBuilder(object):
             extend_existing=extends is not None
         )
         version_table.__versioning_manager__ = self.manager
+        version_table.model = self.model
         return version_table

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -144,12 +144,15 @@ class TableBuilder(object):
         """
         Builds version table.
         """
+        self.parent_table.__versioning_manager__ = self.manager
         columns = self.columns if extends is None else []
         self.manager.plugins.after_build_version_table_columns(self, columns)
-        return sa.schema.Table(
+        version_table = sa.schema.Table(
             extends.name if extends is not None else self.table_name,
             self.parent_table.metadata,
             *columns,
             schema=self.parent_table.schema,
             extend_existing=extends is not None
         )
+        version_table.__versioning_manager__ = self.manager
+        return version_table

--- a/tests/utils/test_get_versioning_manager.py
+++ b/tests/utils/test_get_versioning_manager.py
@@ -1,0 +1,73 @@
+from copy import copy
+from pytest import raises
+import sqlalchemy as sa
+from sqlalchemy_continuum import versioning_manager
+from sqlalchemy_continuum.exc import ClassNotVersioned
+from sqlalchemy_continuum.utils import get_versioning_manager
+
+from tests import TestCase
+
+
+class TestGetVersioningManager(TestCase):
+    def create_models(self):
+        """
+        Creates many-to-many relationship between Article and Tag
+        Article is versioned. But Tag is not versioned
+        """
+        class Article(self.Model):
+            __tablename__ = 'article'
+            __versioned__ = copy(self.options)
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+
+        article_tag = sa.Table(
+            'article_tag',
+            self.Model.metadata,
+            sa.Column(
+                'article_id',
+                sa.Integer,
+                sa.ForeignKey('article.id', ondelete='CASCADE'),
+                primary_key=True,
+            ),
+            sa.Column(
+                'tag_id',
+                sa.Integer,
+                sa.ForeignKey('tag.id', ondelete='CASCADE'),
+                primary_key=True
+            )
+        )
+
+        class Tag(self.Model):
+            __tablename__ = 'tag'
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+            articles = sa.orm.relationship(Article, secondary=article_tag, backref='tags')
+
+        self.Article = Article
+        self.article_tag = article_tag
+        self.Tag = Tag
+
+    def test_parent_class(self):
+        assert get_versioning_manager(self.Article) == versioning_manager
+
+    def test_parent_table(self):
+        assert get_versioning_manager(self.Article.__table__) == versioning_manager
+
+    def test_version_class(self):
+        assert get_versioning_manager(self.ArticleVersion) == versioning_manager
+
+    def test_version_table(self):
+        assert get_versioning_manager(self.ArticleVersion.__table__) == versioning_manager
+
+    def test_association_table(self):
+        assert get_versioning_manager(self.article_tag) == versioning_manager
+
+    def test_aliased_class(self):
+        assert get_versioning_manager(sa.orm.aliased(self.Article)) == versioning_manager
+        assert get_versioning_manager(sa.orm.aliased(self.ArticleVersion)) == versioning_manager
+
+    def test_unknown_class(self):
+        with raises(ClassNotVersioned):
+            get_versioning_manager(self.Tag)

--- a/tests/utils/test_version_table.py
+++ b/tests/utils/test_version_table.py
@@ -1,0 +1,90 @@
+import pytest
+import datetime
+import sqlalchemy as sa
+from tests import TestCase, uses_native_versioning
+
+from sqlalchemy_continuum.utils import version_table
+
+class TestVersionTableDefault(TestCase):
+
+    def create_models(self):
+        super().create_models()
+
+        article_author_table = sa.Table(
+            'article_author',
+            self.Model.metadata,
+            sa.Column('article_id', sa.Integer, sa.ForeignKey('article.id'), primary_key=True, nullable=False),
+            sa.Column('author_id', sa.Integer, sa.ForeignKey('author.id'), primary_key=True, nullable=False),
+            sa.Column('created_date', sa.DateTime, nullable=False, server_default=sa.func.current_timestamp(), default=datetime.datetime.utcnow),
+        )
+
+        user_activity_table = sa.Table(
+            'user_activity',
+            self.Model.metadata,
+            sa.Column('user_id', sa.INTEGER, sa.ForeignKey('user.id'), nullable=False),
+            sa.Column('login_time', sa.DateTime, nullable=False),
+            sa.Column('logout_time', sa.DateTime, nullable=False)
+        )
+        class Author(self.Model):
+            __tablename__ = 'author'
+            __versioned__ = {
+                'table_name': '%s_custom'
+            }
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+            articles = sa.orm.relationship('Article', secondary=article_author_table, backref='author')
+
+        class User(self.Model):
+            __tablename__ = 'user'
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+
+        self.User = User
+        self.Author = Author
+        self.article_author_table = article_author_table
+        self.user_activity_table = user_activity_table
+
+    def test_version_table_with_model(self):
+        ArticleVersionTableName = version_table(self.Article.__table__)
+        assert ArticleVersionTableName.fullname == 'article_version'
+
+    def test_version_table_with_association_table(self):
+        ArticleAuthorVersionedTableName = version_table(self.article_author_table)
+        assert ArticleAuthorVersionedTableName.fullname == 'article_author_version'
+
+    def test_version_table_with_model_version_attr(self):
+        AuthorVersionedTableName = version_table(self.Author.__table__)
+        assert AuthorVersionedTableName.fullname == 'author_custom'
+
+    def test_version_table_with_non_version_model(self):
+        with pytest.raises(KeyError):
+            version_table(self.User.__table__)
+    
+    def test_version_table_with_non_version_table(self):
+        with pytest.raises(KeyError):
+            version_table(self.user_activity_table)
+        
+class TestVersionTableUserDefined(TestVersionTableDefault):
+
+
+    @property
+    def options(self):
+        return {
+            'create_models': self.should_create_models,
+            'native_versioning': uses_native_versioning(),
+            'base_classes': (self.Model, ),
+            'strategy': self.versioning_strategy,
+            'transaction_column_name': self.transaction_column_name,
+            'end_transaction_column_name': self.end_transaction_column_name,
+            'table_name': '%s_user_defined'
+        }
+
+    def test_version_table_with_model(self):
+        ArticleVersionTableName = version_table(self.Article.__table__)
+        assert ArticleVersionTableName.fullname == 'article_user_defined'
+
+    def test_version_table_with_association_table(self):
+        ArticleAuthorVersionedTableName = version_table(self.article_author_table)
+        assert ArticleAuthorVersionedTableName.fullname == 'article_author_user_defined'
+


### PR DESCRIPTION
Hi,

Raising PR in reference to issue #[238](https://github.com/kvesteri/sqlalchemy-continuum/issues/238), as per solution suggested by @aditya051293 .

complete commit message: Fix #238: handling hardcoded  string with options.tablename attribute via version_manager

Along with above change  i was getting an SAWarning showing
 
`sqlalchemy_continuum/relationship_builder.py:51: SAWarning: implicitly coercing SELECT object to scalar subquery; please use the .scalar_subquery() method to produce a scalar subquery.
  return getattr(self.remote_cls, tx_column) == (`

have used same solution used by @TomGoBravo in PR #269 , 

complete commit message: fix for relationship_builder.py:51 SAWarning: implicitly coercing SELECT object to scalar subquery

could you please review if changes are ok?

Thanks