### PR TITLE
tests: Fix testcase for flask-login 0.6.2

### DIFF
--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -239,7 +239,7 @@ class TestFlaskPluginWithFlaskSQLAlchemyExtension(object):
         self.db.init_app(self.app)
         self.app.secret_key = 'secret'
         self.app.debug = True
-        self.context = self.app.test_request_context()
+        self.context = self.app.app_context()
         self.context.push()
         self.db.create_all()
 

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -239,7 +239,6 @@ class TestFlaskPluginWithFlaskSQLAlchemyExtension(object):
         self.db.init_app(self.app)
         self.app.secret_key = 'secret'
         self.app.debug = True
-        self.client = self.app.test_client()
         self.context = self.app.test_request_context()
         self.context.push()
         self.db.create_all()
@@ -252,7 +251,6 @@ class TestFlaskPluginWithFlaskSQLAlchemyExtension(object):
         self.db.engine.dispose()
         self.context.pop()
         self.context = None
-        self.client = None
         self.app = None
 
     def test_version_relations(self):

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -69,10 +69,6 @@ class TestFlaskPlugin(TestCase):
             s['_user_id'] = user.id
         return user
 
-    def logout(self, user=None):
-        with self.client.session_transaction() as s:
-            s['_user_id'] = None
-
     def create_models(self):
         TestCase.create_models(self)
 


### PR DESCRIPTION
In flask-login 0.6.2 they have started using `g` to save the user.
Ref: https://github.com/maxcountryman/flask-login/commit/359fb004f153635952a7d32ded1bbd6d74ec2561#

This is causing an issue with our tests because earlier the user was
stored in a request context. But `g` is stored within an app context.

We need to explicitly clear the `g` to get this to work correctly