### PR TITLE
Fix SAWarning for scalar_subquery warning SQLA<1.4

### DIFF
--- a/sqlalchemy_continuum/fetcher.py
+++ b/sqlalchemy_continuum/fetcher.py
@@ -90,11 +90,13 @@ class VersionObjectFetcher(object):
             )
             .correlate(table)
         )
-        return query
+        try:
+            return query.scalar_subquery()
+        except AttributeError:  # SQLAlchemy < 1.4
+            return query.as_scalar()
 
     def _next_prev_query(self, obj, next_or_prev='next'):
         session = sa.orm.object_session(obj)
-
         return (
             session.query(obj.__class__)
             .filter(

--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -47,18 +47,22 @@ class RelationshipBuilder(object):
     def many_to_one_subquery(self, obj):
         tx_column = option(obj, 'transaction_column_name')
         reflector = VersionExpressionReflector(obj, self.property)
-
-        return getattr(self.remote_cls, tx_column) == (
-            sa.select(
-                [sa.func.max(getattr(self.remote_cls, tx_column))]
-            ).where(
-                sa.and_(
-                    getattr(self.remote_cls, tx_column) <=
-                    getattr(obj, tx_column),
-                    reflector(self.property.primaryjoin)
-                )
+        subquery = sa.select(
+            [sa.func.max(getattr(self.remote_cls, tx_column))]
+        ).where(
+            sa.and_(
+                getattr(self.remote_cls, tx_column) <=
+                getattr(obj, tx_column),
+                reflector(self.property.primaryjoin)
             )
         )
+        try:
+            subquery = subquery.scalar_subquery()
+        except AttributeError:  # SQLAlchemy < 1.4
+            subquery = subquery.as_scalar()
+
+
+        return getattr(self.remote_cls, tx_column) == subquery
 
     def query(self, obj):
         session = sa.orm.object_session(obj)

--- a/sqlalchemy_continuum/schema.py
+++ b/sqlalchemy_continuum/schema.py
@@ -25,6 +25,10 @@ def get_end_tx_column_query(
             ]
         )
     )
+    try:
+        tx_criterion = tx_criterion.scalar_subquery()
+    except AttributeError:  # SQLAlchemy < 1.4
+        tx_criterion = tx_criterion.as_scalar()
     return sa.select(
         columns=[
             getattr(v1.c, column)

--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -226,7 +226,7 @@ class UnitOfWork(object):
             return sa.select(
                 [sa.text('max_1')],
                 from_obj=[
-                    sa.sql.expression.alias(subquery, name='subquery')
+                    sa.sql.expression.alias(subquery.subquery() if hasattr(subquery, 'subquery') else subquery, name='subquery')
                 ]
             )
         return subquery


### PR DESCRIPTION
Attempt to fix all the scalar_subquery warning identified in this [action_job run](https://github.com/kvesteri/sqlalchemy-continuum/runs/8106322990?check_suite_focus=true) as part of #263 , used same sol used in #269  by @TomGoBravo 

Pytest run on Master: `345 failed, 309 passed, 14 skipped, 302 warnings, 90 errors`
Pytest run after changes: `345 failed, 309 passed, 14 skipped, 238 warnings, 90 errors`
