### PR TITLE
Fix for SQLA>1.4 warnings for relationship in test(s)

### DIFF
--- a/tests/relationships/test_association_table_relations.py
+++ b/tests/relationships/test_association_table_relations.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 from sqlalchemy import PrimaryKeyConstraint
 from sqlalchemy.orm import relationship
 from tests import TestCase, create_test_cases
+from packaging import version as py_pkg_version
 
 
 class AssociationTableRelationshipsTestCase(TestCase):
@@ -17,8 +18,11 @@ class AssociationTableRelationshipsTestCase(TestCase):
 
             article_id = sa.Column(sa.Integer, sa.ForeignKey('article.id'))
             author_id = sa.Column(sa.Integer, sa.ForeignKey('author.id'))
-            author = relationship('Author')
-            article = relationship('Article')
+            relationship_kwargs = {}
+            if py_pkg_version.parse(sa.__version__) >= py_pkg_version.parse('1.4.0'):
+                relationship_kwargs.update({'overlaps': 'articles'})
+            author = relationship('Author', **relationship_kwargs)
+            article = relationship('Article', **relationship_kwargs)
 
         self.PublishedArticle = PublishedArticle
 

--- a/tests/relationships/test_custom_condition_relations.py
+++ b/tests/relationships/test_custom_condition_relations.py
@@ -1,6 +1,6 @@
 import sqlalchemy as sa
 from tests import TestCase, create_test_cases
-
+from packaging import version as py_pkg_version
 
 class CustomConditionRelationsTestCase(TestCase):
     def create_models(self):
@@ -26,12 +26,19 @@ class CustomConditionRelationsTestCase(TestCase):
             article_id = sa.Column(sa.Integer, sa.ForeignKey(Article.id))
             category = sa.Column(sa.Unicode(20))
 
+        if py_pkg_version.parse(sa.__version__) < py_pkg_version.parse('1.4.0'):
+            primary_key_overlaps = {}
+            secondary_key_overlaps = {}
+        else:
+            primary_key_overlaps = {'overlaps': 'secondary_tags, Article'}
+            secondary_key_overlaps = {'overlaps': 'primary_tags, Article'}
         Article.primary_tags = sa.orm.relationship(
             Tag,
             primaryjoin=sa.and_(
                 Tag.article_id == Article.id,
                 Tag.category == u'primary'
             ),
+            **primary_key_overlaps
         )
 
         Article.secondary_tags = sa.orm.relationship(
@@ -40,6 +47,7 @@ class CustomConditionRelationsTestCase(TestCase):
                 Tag.article_id == Article.id,
                 Tag.category == u'secondary'
             ),
+            **secondary_key_overlaps
         )
 
         self.Article = Article


### PR DESCRIPTION
Attempt to address SQLA Relationship warning(s) happening in test files `test_association_table_relations` and `test_custom_condition_relations` to reduce warnings in [action job run for sqla > 1.4](https://github.com/kvesteri/sqlalchemy-continuum/runs/8106322990?check_suite_focus=true) in cont. for #263 

pytest run in master : `345 failed, 309 passed, 14 skipped, 302 warnings, 90 errors`
pytest run after changes : `345 failed, 309 passed, 14 skipped, 278 warnings, 90 errors`