### PR TITLE
SAWarning: fix secondary join for association table(s)

### DIFF
--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -97,7 +97,7 @@ class RelationshipBuilder(object):
                 return self.many_to_one_criteria(obj)
         else:
             reflector = VersionExpressionReflector(obj, self.property)
-            return reflector(self.property.primaryjoin)
+            return reflector(self.property.primaryjoin if self.property.secondaryjoin is None else self.property.secondaryjoin)
 
     def many_to_many_criteria(self, obj):
         """


### PR DESCRIPTION
Attempt to address Fix for #305 , to address warning for `SELECT statement has a cartetian product`

tested in local for pytest for SQLA >1.4,<1.4 with SQLITE

> result with Fix in PR:
  SQLA  > 1.4 SQLITE
  659 passed, 99 skipped, 219 warnings 
  SQLA < 1.4 sqlite
  659 passed, 99 skipped, 219 warnings

>Master:
  SQLA  > 1.4 SQLITE
  659 passed, 99 skipped, 220 warnings
  SQLA < 1.4 sqlite
  659 passed, 99 skipped, 220 warnings 