### PR TITLE
Fix deadlock in mysql on concurrent inserts

### DIFF
--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -258,30 +258,24 @@ class UnitOfWork(object):
                 except AttributeError:  # SQLAlchemy < 1.4
                     subquery = subquery.as_scalar()
 
+                vobj_tx_col = getattr(class_, tx_column_name(version_obj))
+                values = {end_tx_column_name(version_obj): self.current_transaction.id}
                 query = (
-                    session.query(class_.__table__)
-                    .filter(
-                        sa.and_(
-                            getattr(
-                                class_,
-                                tx_column_name(version_obj)
-                            ) == subquery,
-                            *[
-                                getattr(version_obj, pk) ==
-                                getattr(class_.__table__.c, pk)
-                                for pk in get_primary_keys(class_)
-                                if pk != tx_column_name(class_)
-                            ]
-                        )
+                    sa.update(class_)
+                    .values(values)
+                    .where(
+                        vobj_tx_col == subquery,
+                        *[
+                            getattr(version_obj, pk) ==
+                            getattr(class_.__table__.c, pk)
+                            for pk in get_primary_keys(class_)
+                            if pk != tx_column_name(class_)
+                        ]
                     )
+                    .execution_options(synchronize_session=False)
                 )
-                query.update(
-                    {
-                        end_tx_column_name(version_obj):
-                        self.current_transaction.id
-                    },
-                    synchronize_session=False
-                )
+                session.execute(query)
+
 
     def create_association_versions(self, session):
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -51,12 +51,20 @@ def get_dns_from_driver(driver):
         raise Exception('Unknown driver given: %r' % driver)
 
 
+def _get_db():
+    return os.environ.get('DB', 'sqlite')
+
+
 def get_driver_name(driver):
     return driver[0:-len('-native')] if driver.endswith('-native') else driver
 
 
 def uses_native_versioning():
-    return os.environ.get('DB', 'sqlite').endswith('-native')
+    return _get_db().endswith('-native')
+
+
+def is_sqlite():
+    return _get_db() == 'sqlite'
 
 
 class TestCase(object):
@@ -84,7 +92,7 @@ class TestCase(object):
         self.Model = declarative_base()
         make_versioned(options=self.options)
 
-        driver = os.environ.get('DB', 'sqlite')
+        driver = _get_db()
         self.driver = get_driver_name(driver)
         versioning_manager.plugins = self.plugins
         versioning_manager.transaction_cls = self.transaction_cls

--- a/tests/builders/test_table_builder.py
+++ b/tests/builders/test_table_builder.py
@@ -2,7 +2,7 @@ from copy import copy
 from datetime import datetime
 import sqlalchemy as sa
 from sqlalchemy_continuum import version_class
-from tests import TestCase
+from tests import TestCase, is_sqlite
 from pytest import mark
 
 
@@ -71,7 +71,8 @@ class TestTableBuilderWithOnUpdate(TestCase):
         table = version_class(self.Article).__table__
         assert table.c.last_update.onupdate is None
 
-@mark.skipif("os.environ.get('DB') == 'sqlite'")
+
+@mark.skipif('is_sqlite()')
 class TestTableBuilderInOtherSchema(TestCase):
     def create_models(self):
         class Article(self.Model):
@@ -97,4 +98,3 @@ class TestTableBuilderInOtherSchema(TestCase):
         table = version_class(self.Article).__table__
         assert table.schema is not None
         assert table.schema == self.Article.__table__.schema
-

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -3,7 +3,7 @@ from pytest import mark
 import sqlalchemy as sa
 from sqlalchemy_continuum import versioning_manager
 
-from tests import TestCase, create_test_cases
+from tests import TestCase, create_test_cases, is_sqlite
 
 
 class ManyToManyRelationshipsTestCase(TestCase):
@@ -273,7 +273,7 @@ class TestManyToManyRelationshipWithViewOnly(TestCase):
 
 
 class TestManyToManySelfReferential(TestCase):
-    
+
     def create_models(self):
         class Article(self.Model):
             __tablename__ = 'article'
@@ -324,8 +324,8 @@ class TestManyToManySelfReferential(TestCase):
 
         assert len(reference1.versions[0].cited_by) == 1
         assert article.versions[0] in reference1.versions[0].cited_by
-        
-        
+
+
     def test_multiple_inserts_over_multiple_transactions(self):
         if (
             self.driver == 'mysql' and
@@ -370,7 +370,7 @@ class TestManyToManySelfReferential(TestCase):
         assert article.versions[2] in reference1.versions[2].cited_by
 
 
-@mark.skipif("os.environ.get('DB') == 'sqlite'")
+@mark.skipif('is_sqlite()')
 class TestManyToManySelfReferentialInOtherSchema(TestManyToManySelfReferential):
     def create_models(self):
         class Article(self.Model):
@@ -416,7 +416,7 @@ class TestManyToManySelfReferentialInOtherSchema(TestManyToManySelfReferential):
         TestManyToManySelfReferential.create_tables(self)
 
 
-@mark.skipif("os.environ.get('DB') == 'sqlite'")
+@mark.skipif('is_sqlite()')
 class ManyToManyRelationshipsInOtherSchemaTestCase(ManyToManyRelationshipsTestCase):
     def create_models(self):
         class Article(self.Model):
@@ -473,4 +473,3 @@ class ManyToManyRelationshipsInOtherSchemaTestCase(ManyToManyRelationshipsTestCa
         ManyToManyRelationshipsTestCase.create_tables(self)
 
 create_test_cases(ManyToManyRelationshipsInOtherSchemaTestCase)
-

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -1,12 +1,10 @@
-import os
 import sqlalchemy as sa
-from six import PY3
 from pytest import mark
 from sqlalchemy.ext.declarative import declarative_base
-from tests import TestCase
+from tests import TestCase, is_sqlite
 
 
-@mark.skipif("os.environ.get('DB') == 'sqlite'")
+@mark.skipif('is_sqlite()')
 class TestCustomSchema(TestCase):
     def create_models(self):
         self.Model = declarative_base(metadata=sa.MetaData(schema='continuum'))

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,9 +1,8 @@
 import sqlalchemy as sa
 from sqlalchemy_continuum import versioning_manager
-from tests import TestCase
+from tests import TestCase, is_sqlite
 from pytest import mark
 from sqlalchemy_continuum.plugins import TransactionMetaPlugin
-
 
 
 class TestTransaction(TestCase):
@@ -74,7 +73,7 @@ class TestAssigningUserClass(TestCase):
         assert isinstance(attr.property.columns[0].type, sa.Unicode)
 
 
-@mark.skipif("os.environ.get('DB') == 'sqlite'")
+@mark.skipif('is_sqlite()')
 class TestAssigningUserClassInOtherSchema(TestCase):
     user_cls = 'User'
 
@@ -99,4 +98,3 @@ class TestAssigningUserClassInOtherSchema(TestCase):
     def test_can_build_transaction_model(self):
         # If create_models didn't crash this should be good
         pass
-

--- a/tests/test_validity_strategy_multithreaded.py
+++ b/tests/test_validity_strategy_multithreaded.py
@@ -1,0 +1,74 @@
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import func
+from sqlalchemy.orm import sessionmaker
+from tests import TestCase
+from threading import Thread
+
+
+NUM_ROWS = 100
+NUM_THREADS = 4
+
+
+class TestValidityStrategyMultithreaded(TestCase):
+    class WrappedThread(Thread):
+        """
+        Wrapper around `threading.Thread` that propagates exceptions.
+
+        REF: https://gist.github.com/sbrugman/59b3535ebcd5aa0e2598293cfa58b6ab
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.exc = None
+
+        def run(self):
+            try:
+                super().run()
+            except BaseException as e:
+                self.exc = e
+
+        def join(self, timeout=None):
+            super().join(timeout)
+            if self.exc:
+                raise self.exc
+
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = 'article'
+            __versioned__ = {
+                'base_classes': (self.Model, ),
+                'strategy': 'validity'
+            }
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+            name = sa.Column(sa.Unicode(255))
+
+        self.Article = Article
+
+    @pytest.mark.skipif("os.environ.get('DB') == 'sqlite'")
+    def test_for_deadlock_with_many_multithreaded_inserts(self):
+        threads = [
+            self.WrappedThread(target=self._insert_articles, args=(n,))
+            for n in range(0, NUM_THREADS)
+        ]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+
+    def _insert_articles(self, num):
+        Session = sessionmaker(bind=self.engine.connect())
+        session = Session(autoflush=False)
+        for i in range(1, NUM_ROWS+1):
+            article = self.Article(name=f'Article {num}-{i:04}')
+            session.add(article)
+            session.commit()
+            article.name = article.name + '.2'
+            session.commit()
+        assert session.query(func.count(self.Article.id)). \
+               where(self.Article.name.like(f'Article {num}-%')). \
+               scalar() == NUM_ROWS

--- a/tests/test_validity_strategy_multithreaded.py
+++ b/tests/test_validity_strategy_multithreaded.py
@@ -59,7 +59,6 @@ class TestValidityStrategyMultithreaded(TestCase):
         for t in threads:
             t.join()
 
-
     def _insert_articles(self, num):
         Session = sessionmaker(bind=self.engine.connect())
         session = Session(autoflush=False)
@@ -70,5 +69,5 @@ class TestValidityStrategyMultithreaded(TestCase):
             article.name = article.name + '.2'
             session.commit()
         assert session.query(func.count(self.Article.id)). \
-               where(self.Article.name.like(f'Article {num}-%')). \
+               filter(self.Article.name.like(f'Article {num}-%')). \
                scalar() == NUM_ROWS

--- a/tests/test_validity_strategy_multithreaded.py
+++ b/tests/test_validity_strategy_multithreaded.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy import func
 from sqlalchemy.orm import sessionmaker
-from tests import TestCase
+from tests import TestCase, is_sqlite
 from threading import Thread
 
 
@@ -46,7 +46,7 @@ class TestValidityStrategyMultithreaded(TestCase):
 
         self.Article = Article
 
-    @pytest.mark.skipif("os.environ.get('DB') == 'sqlite'")
+    @pytest.mark.skipif('is_sqlite()')
     def test_for_deadlock_with_many_multithreaded_inserts(self):
         threads = [
             self.WrappedThread(target=self._insert_articles, args=(n,))


### PR DESCRIPTION
When inserting many versioned objects in MySQL concurrently (from separate threads), deadlocks would frequently occur and the inserts would fail. Updating to use the newer ORM-style query while applying the validity strategy  avoids the problem.

Fixes #172