### PR TITLE
Add invalidated condition to rollback event - clear_connection

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -392,7 +392,7 @@ class VersioningManager(object):
 
 
         for connection in dict(self.units_of_work).keys():
-            if connection.closed or conn.connection is connection.connection:
+            if connection.closed or connection.invalidated or conn.connection is connection.connection:
                 uow = self.units_of_work[connection]
                 uow.reset()
                 del self.units_of_work[connection]


### PR DESCRIPTION
This way conn.connection is connection.connection - > self._revalidate_connection() wont be called when a connection is invalidated eg. "Can't reconnect until transaction is rolled back".