### PR TITLE
Revert "FlaskPlugin: use `get_id()` instead of `id` attr"

### DIFF
--- a/sqlalchemy_continuum/plugins/flask.py
+++ b/sqlalchemy_continuum/plugins/flask.py
@@ -36,7 +36,7 @@ def fetch_current_user_id():
     if _app_ctx_stack.top is None or _request_ctx_stack.top is None:
         return
     try:
-        return current_user.get_id()
+        return current_user.id
     except AttributeError:
         return
 

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Flask, url_for
-from flask_login import LoginManager, UserMixin, login_user
+from flask_login import LoginManager, login_user
 from flask_sqlalchemy import SQLAlchemy, _SessionSignalEvents
 from flexmock import flexmock
 
@@ -63,7 +63,7 @@ class TestFlaskPlugin(TestCase):
     def create_models(self):
         TestCase.create_models(self)
 
-        class User(self.Model, UserMixin):
+        class User(self.Model):
             __tablename__ = 'user'
             __versioned__ = {
                 'base_classes': (self.Model, )


### PR DESCRIPTION
This reverts commit 7eda52765ee8bb1c1c5ff193fc3a7ee032e5323f.

This was actually a misinterpretation of the API:

The API expects get_id() to be a unique string, that may or may not be an integer. This feature is only used to uniquely identify the user, but its not the same as the user's primary key.
https://flask-login.readthedocs.io/en/latest/#your-user-class

Please take a note on how get_id() is expected to behave on this feature of flask-login:
https://flask-login.readthedocs.io/en/latest/#alternative-tokens

This means it can return any arbitrary string to identify the user which can be swapped to any other value to invalidate all sessions. This explicitly states that it is not the same as the user's primary id which is also used as foreign key on the table.

sqlalchemy-continuum's transaction tables reference the user with a foreign key of the actual id. If a downstream application uses the alternative-tokens feature as described by the flask-login documentation, this breaks horribly as sqlalchemy-continuum will then try to insert an arbitrary unique string of the user as the foreign key to reference the user in the user table.

Fixes #316
Caused by #149