### PR TITLE
Declare six as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     install_requires=[
         'SQLAlchemy>=1.0.8',
         'SQLAlchemy-Utils>=0.30.12'
+        'six',
     ],
     extras_require=extras_require,
     classifiers=[


### PR DESCRIPTION
It seems that older versions of SQLAlchemy and SQLAlchemy-Utils depended on six, so there was no need to declare it here.

However, latest releases of SQLAlchemy and SQLAlchemy-Utils no longer depend on six, but SQLAlchemy-Continuum does in fact [import six](https://github.com/kvesteri/sqlalchemy-continuum/blob/master/sqlalchemy_continuum/operation.py#L7), so we need to declare it as a dependency.