### PR TITLE
Fix code example to use `append`

### DIFF
--- a/sqlalchemy_continuum/plugins/transaction_meta.py
+++ b/sqlalchemy_continuum/plugins/transaction_meta.py
@@ -5,7 +5,7 @@ You can use the plugin in same way as other plugins::
 
     meta_plugin = TransactionMetaPlugin()
 
-    versioning_manager.plugins.add(meta_plugin)
+    versioning_manager.plugins.append(meta_plugin)
 
 
 TransactionMetaPlugin creates a simple model called TransactionMeta. This class


### PR DESCRIPTION
`add` is the wrong function and results in this plugin not being properly added to the list of plugins.