### PR TITLE
SQLModel support & tests

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ SQLAlchemy-Continuum is a versioning extension for SQLAlchemy.
    queries
    transactions
    native_versioning
+   sqlmodel
    plugins
    configuration
    schema

--- a/docs/sqlmodel.rst
+++ b/docs/sqlmodel.rst
@@ -1,0 +1,42 @@
+SQLModel support
+=================
+
+As of version 1.5 SQLAlchemy-Continuum supports models defined via SQLModel library.
+
+Usage
+-----
+
+Enabling versions for SQLModel tables is identical to pure SQLAlchemy
+
+1. Call make_versioned() before your models are defined.
+2. Add __versioned__ to all models you wish to add versioning to
+
+::
+
+    import sqlmodel
+    import sqlalchemy as sa
+    from sqlalchemy_continuum import make_versioned
+
+
+    make_versioned(user_cls=None)
+
+
+    class Article(sqlmodel.SQLModel, table=True):
+        __versioned__ = {}
+        __tablename__ = 'article'
+
+        id: int | None = sqlmodel.Field(default=None, primary_key=True)
+        name: str = sqlmodel.Field(max_length=255, sa_type=sa.Unicode(255))
+        content: str = sqlmodel.Field(sa_type=sa.UnicodeText)
+
+
+    # after you have defined all your models, call configure_mappers:
+    sa.orm.configure_mappers()
+
+
+Non supported features
+----------------------
+
+Following features are not supported with SQLModel
+
+- `base_classes` parameter for `__versioned__` attribute

--- a/docs/sqlmodel.rst
+++ b/docs/sqlmodel.rst
@@ -13,7 +13,7 @@ Enabling versions for SQLModel tables is identical to pure SQLAlchemy
 
 ::
 
-    import sqlmodel
+    from sqlmodel import SQLModel, Field
     import sqlalchemy as sa
     from sqlalchemy_continuum import make_versioned
 
@@ -21,13 +21,13 @@ Enabling versions for SQLModel tables is identical to pure SQLAlchemy
     make_versioned(user_cls=None)
 
 
-    class Article(sqlmodel.SQLModel, table=True):
+    class Article(SQLModel, table=True):
         __versioned__ = {}
         __tablename__ = 'article'
 
-        id: int | None = sqlmodel.Field(default=None, primary_key=True)
-        name: str = sqlmodel.Field(max_length=255, sa_type=sa.Unicode(255))
-        content: str = sqlmodel.Field(sa_type=sa.UnicodeText)
+        id: int | None = Field(default=None, primary_key=True)
+        name: str = Field(max_length=255, sa_type=sa.Unicode(255))
+        content: str = Field(sa_type=sa.UnicodeText)
 
 
     # after you have defined all your models, call configure_mappers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
 flask = ["Flask>=0.9"]
 flask-login = ["Flask-Login>=0.2.9"]
 flask-sqlalchemy = ["Flask-SQLAlchemy>=1.0"]
+sqlmodel = ['SQLModel>=0.0.24']
 dev = [
     "ruff>=0.1.0",
     "tox>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,13 @@ test = [
     "Flask>=0.9",
     "Flask-Login>=0.2.9",
     "Flask-SQLAlchemy>=1.0",
+    "SQLModel>=0.0.24",
     "packaging",
 ]
 flask = ["Flask>=0.9"]
 flask-login = ["Flask-Login>=0.2.9"]
 flask-sqlalchemy = ["Flask-SQLAlchemy>=1.0"]
-sqlmodel = ['SQLModel>=0.0.24']
+sqlmodel = ["SQLModel>=0.0.24"]
 dev = [
     "ruff>=0.1.0",
     "tox>=4.0.0",

--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -10,6 +10,7 @@ from .dialects.postgresql import create_versioning_trigger_listeners
 from .model_builder import ModelBuilder
 from .relationship_builder import RelationshipBuilder
 from .table_builder import TableBuilder
+from .utils import declarative_base_resolver
 
 
 def prevent_reentry(handler):
@@ -146,7 +147,7 @@ class Builder:
     def build_transaction_class(self):
         if self.manager.pending_classes:
             cls = self.manager.pending_classes[0]
-            self.manager.declarative_base = get_declarative_base(cls)
+            self.manager.declarative_base = declarative_base_resolver(cls)
             self.manager.create_transaction_model()
             self.manager.plugins.after_build_tx_class(self.manager)
 
@@ -167,7 +168,6 @@ class Builder:
         """
         if not self.manager.options['versioning']:
             return
-
         self.build_triggers()
         self.build_tables()
         self.build_transaction_class()

--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -4,7 +4,6 @@ from inspect import getmro
 
 import sqlalchemy as sa
 from sqlalchemy.orm.descriptor_props import ConcreteInheritedProperty
-from ._compat import get_declarative_base
 
 from .dialects.postgresql import create_versioning_trigger_listeners
 from .model_builder import ModelBuilder

--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -3,9 +3,8 @@ from copy import copy
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import column_property
-from ._compat import get_declarative_base
 
-from .utils import adapt_columns, option
+from .utils import adapt_columns, option, declarative_base_resolver
 from .version import VersionClassBase
 
 
@@ -31,7 +30,11 @@ def get_base_class(manager, model):
     """
     Returns all base classes for history model.
     """
-    return option(model, 'base_classes') or (get_declarative_base(model),)
+    return (
+        option(model, 'base_classes')
+        or
+        (declarative_base_resolver(model), )
+    )
 
 
 def version_base(manager, parent_cls, base_class_factory=None):

--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -30,11 +30,7 @@ def get_base_class(manager, model):
     """
     Returns all base classes for history model.
     """
-    return (
-        option(model, 'base_classes')
-        or
-        (declarative_base_resolver(model), )
-    )
+    return option(model, 'base_classes') or (declarative_base_resolver(model),)
 
 
 def version_base(manager, parent_cls, base_class_factory=None):

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from collections import OrderedDict
 from datetime import datetime
 import sys
@@ -12,6 +14,7 @@ from .dialects.postgresql import (
 )
 from .exc import ImproperlyConfigured
 from .factory import ModelFactory
+from .utils import declarative_base_resolver
 
 
 # Compatibility function for datetime.utcnow() deprecation
@@ -152,7 +155,7 @@ class TransactionFactory(ModelFactory):
 
             if manager.user_cls:
                 user_cls = manager.user_cls
-                Base = manager.declarative_base
+                Base = declarative_base_resolver(manager.declarative_base)
                 registry = Base.registry._class_registry
 
                 if isinstance(user_cls, str):

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from collections import OrderedDict
 from datetime import datetime
 import sys

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -9,6 +9,7 @@ from ._compat import (
     get_primary_keys,
     identity,
     naturally_equivalent,
+    get_declarative_base
 )
 
 from .exc import ClassNotVersioned
@@ -424,6 +425,24 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
         if isinstance(col, sa.Column):
             table = version_table(col.table)
             return table.c.get(col.key)
+
+
+class DeclarativeBaseResolver:
+    """Resolves declarative base class from either SQLModel or sqlalchemy registry."""
+    _sa_base = None
+
+    def __call__(self, model):
+        if hasattr(model, "registry"):
+            # This is NOT SQLModel
+            return get_declarative_base(model)
+        else:
+            # SQLModel compatibility
+            if DeclarativeBaseResolver._sa_base is None:
+                DeclarativeBaseResolver._sa_base = model._sa_registry.generate_base()
+            return DeclarativeBaseResolver._sa_base
+
+
+declarative_base_resolver = DeclarativeBaseResolver()
 
 
 def adapt_columns(expr):

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -9,7 +9,7 @@ from ._compat import (
     get_primary_keys,
     identity,
     naturally_equivalent,
-    get_declarative_base
+    get_declarative_base,
 )
 
 from .exc import ClassNotVersioned
@@ -429,10 +429,11 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
 
 class DeclarativeBaseResolver:
     """Resolves declarative base class from either SQLModel or sqlalchemy registry."""
+
     _sa_base = None
 
     def __call__(self, model):
-        if hasattr(model, "registry"):
+        if hasattr(model, 'registry'):
             # This is NOT SQLModel
             return get_declarative_base(model)
         else:

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,0 +1,102 @@
+from copy import copy
+import os
+import pathlib
+
+import sqlmodel
+from sqlmodel import Field, Relationship, Session
+import sqlalchemy as sa
+from sqlalchemy_continuum import make_versioned
+from sqlalchemy_continuum import versioning_manager
+
+from sqlalchemy_continuum.exc import ClassNotVersioned
+from sqlalchemy_continuum.transaction import TransactionFactory
+from sqlalchemy_continuum.utils import version_class
+from tests import TestCase, get_driver_name, get_url_from_driver
+
+
+models_path = pathlib.Path(__file__).parent.absolute() / "_models.py"
+
+
+class SQLModelTestCase(TestCase):
+
+    def setup_method(self, method):
+        self.Model = sqlmodel.SQLModel
+        make_versioned(user_cls=self.user_cls)
+
+        driver = os.environ.get("DB", "sqlite")
+        self.driver = get_driver_name(driver)
+        versioning_manager.plugins = self.plugins
+        versioning_manager.transaction_cls = TransactionFactory()
+        versioning_manager.user_cls = self.user_cls
+
+        self.engine = sa.create_engine(get_url_from_driver(self.driver), echo=True)
+        # self.engine.echo = True
+        self.create_models()
+        sa.orm.configure_mappers()
+
+        if hasattr(self, "Article"):
+            try:
+                self.ArticleVersion = version_class(self.Article)
+            except ClassNotVersioned:
+                pass
+        if hasattr(self, "Tag"):
+            try:
+                self.TagVersion = version_class(self.Tag)
+            except ClassNotVersioned:
+                pass
+
+        self.connection = self.engine.connect()
+        self.session = Session(self.engine, autoflush=False)
+
+        if driver == "postgres-native":
+            self.session.execute(sa.text("CREATE EXTENSION IF NOT EXISTS hstore"))
+
+        # Run any other custom SQL in here
+        self.create_schema("other")
+        self.session.commit()
+
+        # Using an engine here instead of connection will call commit for us,
+        # which lets us use the same syntax for 1.4 and 2.0
+        self.Model.metadata.create_all(self.engine)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
+        for entity in (
+            "Article",
+            "Tag",
+            "ArticleVersion",
+            "TagVersion",
+            "User",
+            "ArticleTagLink",
+            "ArticleReferences",
+        ):
+            if hasattr(self, entity):
+                self.Model.metadata.remove(getattr(self, entity).__table__)
+        self.Model.metadata.clear()
+        self.Model._sa_registry._class_registry.clear()
+
+    def create_models(self):
+
+        class Article(self.Model, table=True):
+            __tablename__ = "article"
+            __versioned__ = {}
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(
+                sa_type=sa.UnicodeText, default=None, nullable=True
+            )
+            tags: list["Tag"] = Relationship(back_populates="article")
+
+        class Tag(self.Model, table=True):
+            __tablename__ = "tag"
+            __versioned__ = {}
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            article_id: int | None = Field(default=None, foreign_key="article.id")
+            article: Article = Relationship(back_populates="tags")
+
+        self.Article = Article
+        self.Tag = Tag

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,7 +1,5 @@
-from copy import copy
 import os
-import pathlib
-
+from typing import Union
 import sqlmodel
 from sqlmodel import Field, Relationship, Session
 import sqlalchemy as sa
@@ -14,16 +12,12 @@ from sqlalchemy_continuum.utils import version_class
 from tests import TestCase, get_driver_name, get_url_from_driver
 
 
-models_path = pathlib.Path(__file__).parent.absolute() / "_models.py"
-
-
 class SQLModelTestCase(TestCase):
-
     def setup_method(self, method):
         self.Model = sqlmodel.SQLModel
         make_versioned(user_cls=self.user_cls)
 
-        driver = os.environ.get("DB", "sqlite")
+        driver = os.environ.get('DB', 'sqlite')
         self.driver = get_driver_name(driver)
         versioning_manager.plugins = self.plugins
         versioning_manager.transaction_cls = TransactionFactory()
@@ -34,12 +28,12 @@ class SQLModelTestCase(TestCase):
         self.create_models()
         sa.orm.configure_mappers()
 
-        if hasattr(self, "Article"):
+        if hasattr(self, 'Article'):
             try:
                 self.ArticleVersion = version_class(self.Article)
             except ClassNotVersioned:
                 pass
-        if hasattr(self, "Tag"):
+        if hasattr(self, 'Tag'):
             try:
                 self.TagVersion = version_class(self.Tag)
             except ClassNotVersioned:
@@ -48,11 +42,11 @@ class SQLModelTestCase(TestCase):
         self.connection = self.engine.connect()
         self.session = Session(self.engine, autoflush=False)
 
-        if driver == "postgres-native":
-            self.session.execute(sa.text("CREATE EXTENSION IF NOT EXISTS hstore"))
+        if driver == 'postgres-native':
+            self.session.execute(sa.text('CREATE EXTENSION IF NOT EXISTS hstore'))
 
         # Run any other custom SQL in here
-        self.create_schema("other")
+        self.create_schema('other')
         self.session.commit()
 
         # Using an engine here instead of connection will call commit for us,
@@ -62,13 +56,13 @@ class SQLModelTestCase(TestCase):
     def teardown_method(self, method):
         super().teardown_method(method)
         for entity in (
-            "Article",
-            "Tag",
-            "ArticleVersion",
-            "TagVersion",
-            "User",
-            "ArticleTagLink",
-            "ArticleReferences",
+            'Article',
+            'Tag',
+            'ArticleVersion',
+            'TagVersion',
+            'User',
+            'ArticleTagLink',
+            'ArticleReferences',
         ):
             if hasattr(self, entity):
                 self.Model.metadata.remove(getattr(self, entity).__table__)
@@ -76,9 +70,8 @@ class SQLModelTestCase(TestCase):
         self.Model._sa_registry._class_registry.clear()
 
     def create_models(self):
-
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
@@ -87,16 +80,16 @@ class SQLModelTestCase(TestCase):
             description: str = Field(
                 sa_type=sa.UnicodeText, default=None, nullable=True
             )
-            tags: list["Tag"] = Relationship(back_populates="article")
+            tags: list['Tag'] = Relationship(back_populates='article')
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
             __versioned__ = {}
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
-            article_id: int | None = Field(default=None, foreign_key="article.id")
-            article: Article = Relationship(back_populates="tags")
+            article_id: Union[int, None] = Field(default=None, foreign_key='article.id')
+            article: Article = Relationship(back_populates='tags')
 
         self.Article = Article
         self.Tag = Tag

--- a/tests/sqlmodel/relationships/test_many_to_many_relations.py
+++ b/tests/sqlmodel/relationships/test_many_to_many_relations.py
@@ -1,5 +1,5 @@
-from typing import Self
 import pytest
+from typing import Union
 from pytest import mark
 import sqlalchemy as sa
 from sqlmodel import Field, Relationship
@@ -11,35 +11,34 @@ from tests.sqlmodel import SQLModelTestCase
 
 class ManyToManyRelationshipsTestCase(SQLModelTestCase):
     def create_models(self):
-
         class ArticleTagLink(self.Model, table=True):
-            __tablename__ = "article_tag"
-            article_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_tag'
+            article_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: int | None = Field(
-                default=None, foreign_key="tag.id", primary_key=True
+            tag_id: Union[int, None] = Field(
+                default=None, foreign_key='tag.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            tags: list["Tag"] = Relationship(
-                back_populates="articles", link_model=ArticleTagLink
+            content: str = Field(default='')
+            tags: list['Tag'] = Relationship(
+                back_populates='articles', link_model=ArticleTagLink
             )
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
-                back_populates="tags", link_model=ArticleTagLink
+                back_populates='tags', link_model=ArticleTagLink
             )
 
         self.Article = Article
@@ -47,29 +46,29 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
         self.ArticleTagLink = ArticleTagLink
 
     def test_version_relations(self):
-        article = self.Article(name="Some article", content="Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         assert not article.versions[0].tags
 
     def test_single_insert(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
         assert len(article.versions[0].tags) == 1
 
     def test_unrelated_change(self):
-        tag1 = self.Tag(name="some tag")
-        tag2 = self.Tag(name="some tag2")
+        tag1 = self.Tag(name='some tag')
+        tag2 = self.Tag(name='some tag2')
 
         self.session.add(tag1)
         self.session.add(tag2)
         self.session.commit()
 
         article1 = self.Article(
-            name="Some article",
+            name='Some article',
         )
         article1.tags.append(tag1)
 
@@ -77,78 +76,78 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
         self.session.commit()
 
         article2 = self.Article()
-        article2.name = "Some article2"
+        article2.name = 'Some article2'
         article2.tags.append(tag1)
 
         self.session.add(article2)
         self.session.commit()
 
-        article1.name = "Some other name"
+        article1.name = 'Some other name'
         self.session.commit()
 
         assert len(article1.versions[1].tags) == 1
 
     def test_multi_insert(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
-        article.tags.append(self.Tag(name="another tag"))
+        article.tags.append(self.Tag(name='another tag'))
         self.session.add(article)
         self.session.commit()
         assert len(article.versions[0].tags) == 2
 
     def test_collection_with_multiple_entries(self):
-        article = self.Article(name="Some article", content="Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
-        article.tags = [self.Tag(name="some tag"), self.Tag(name="another tag")]
+        article.tags = [self.Tag(name='some tag'), self.Tag(name='another tag')]
         self.session.commit()
         assert len(article.versions[0].tags) == 2
 
     def test_delete_single_association(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
         article.tags.remove(tag)
-        article.name = "Updated name"
+        article.name = 'Updated name'
         self.session.commit()
         tags = article.versions[1].tags
         assert len(tags) == 0
 
     def test_delete_multiple_associations(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
-        tag2 = self.Tag(name="another tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
+        tag2 = self.Tag(name='another tag')
         article.tags.append(tag)
         article.tags.append(tag2)
         self.session.add(article)
         self.session.commit()
         article.tags.remove(tag)
         article.tags.remove(tag2)
-        article.name = "Updated name"
+        article.name = 'Updated name'
         self.session.commit()
         assert len(article.versions[1].tags) == 0
 
     def test_remove_node_but_not_the_link(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
         self.session.delete(tag)
-        article.name = "Updated name"
+        article.name = 'Updated name'
         self.session.commit()
         tags = article.versions[1].tags
         assert len(tags) == 0
 
     def test_multiple_parent_objects_added_within_same_transaction(self):
-        article = self.Article(name="Some article")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
-        article2 = self.Article(name="Some article")
-        tag2 = self.Tag(name="some tag")
+        article2 = self.Article(name='Some article')
+        tag2 = self.Tag(name='some tag')
         article2.tags.append(tag2)
         self.session.add(article2)
         self.session.commit()
@@ -159,29 +158,29 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
         assert tags == [tag.versions[0]]
 
     def test_relations_with_varying_transactions(self):
-        if self.driver == "mysql" and self.connection.dialect.server_version_info < (
+        if self.driver == 'mysql' and self.connection.dialect.server_version_info < (
             5,
             6,
         ):
             pytest.skip()
 
         # one article with one tag
-        article = self.Article(name="Some article")
-        tag1 = self.Tag(name="some tag")
+        article = self.Article(name='Some article')
+        tag1 = self.Tag(name='some tag')
         article.tags.append(tag1)
         self.session.add(article)
         self.session.commit()
 
         # update article and tag, add a 2nd tag
-        tag2 = self.Tag(name="some other tag")
+        tag2 = self.Tag(name='some other tag')
         article.tags.append(tag2)
-        tag1.name = "updated tag1"
-        article.name = "updated article"
+        tag1.name = 'updated tag1'
+        article.name = 'updated article'
         self.session.commit()
 
         # update article and first tag only
-        tag1.name = "updated tag1 x2"
-        article.name = "updated article x2"
+        tag1.name = 'updated tag1 x2'
+        article.name = 'updated article x2'
         self.session.commit()
 
         assert len(article.versions[0].tags) == 1
@@ -202,36 +201,37 @@ create_test_cases(ManyToManyRelationshipsTestCase)
 class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
     def create_models(self):
         class ArticleTagLink(self.Model, table=True):
-            __tablename__ = "article_tag"
-            article_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_tag'
+            article_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: int | None = Field(
-                default=None, foreign_key="tag.id", primary_key=True
+            tag_id: Union[int, None] = Field(
+                default=None, foreign_key='tag.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            tags: list["Tag"] = Relationship(
-                back_populates="articles", link_model=ArticleTagLink,
-                sa_relationship_kwargs={"viewonly": True}
+            content: str = Field(default='')
+            tags: list['Tag'] = Relationship(
+                back_populates='articles',
+                link_model=ArticleTagLink,
+                sa_relationship_kwargs={'viewonly': True},
             )
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
-                back_populates="tags",
+                back_populates='tags',
                 link_model=ArticleTagLink,
-                sa_relationship_kwargs={"viewonly": True}
+                sa_relationship_kwargs={'viewonly': True},
             )
 
         self.ArticleTagLink = ArticleTagLink
@@ -243,41 +243,38 @@ class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
 
 
 class TestManyToManySelfReferential(SQLModelTestCase):
-
     def create_models(self):
         class ArticleReferences(self.Model, table=True):
-            __tablename__ = "article_references"
-            referring_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_references'
+            referring_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            referred_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            referred_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            references: list["Article"] = Relationship(
+            content: str = Field(default='')
+            references: list['Article'] = Relationship(
                 link_model=ArticleReferences,
                 sa_relationship_kwargs={
-                    "primaryjoin": "Article.id == ArticleReferences.referring_id",
-                    "secondaryjoin": "Article.id == ArticleReferences.referred_id",
-                    "backref": "cited_by",
-                  }
+                    'primaryjoin': 'Article.id == ArticleReferences.referring_id',
+                    'secondaryjoin': 'Article.id == ArticleReferences.referred_id',
+                    'backref': 'cited_by',
+                },
             )
-
 
         self.Article = Article
         self.ArticleReferences = ArticleReferences
 
     def test_single_insert(self):
-
-        article = self.Article(name="article")
-        reference1 = self.Article(name="referred article 1")
+        article = self.Article(name='article')
+        reference1 = self.Article(name='referred article 1')
         article.references.append(reference1)
         self.session.add(article)
         self.session.commit()
@@ -289,29 +286,29 @@ class TestManyToManySelfReferential(SQLModelTestCase):
         assert article.versions[0] in reference1.versions[0].cited_by
 
     def test_multiple_inserts_over_multiple_transactions(self):
-        if self.driver == "mysql" and self.connection.dialect.server_version_info < (
+        if self.driver == 'mysql' and self.connection.dialect.server_version_info < (
             5,
             6,
         ):
             pytest.skip()
 
         # create 1 article with 1 reference
-        article = self.Article(name="article")
-        reference1 = self.Article(name="reference 1")
+        article = self.Article(name='article')
+        reference1 = self.Article(name='reference 1')
         article.references.append(reference1)
         self.session.add(article)
         self.session.commit()
 
         # update existing, add a 2nd reference
-        article.name = "Updated article"
-        reference1.name = "Updated reference 1"
-        reference2 = self.Article(name="reference 2")
+        article.name = 'Updated article'
+        reference1.name = 'Updated reference 1'
+        reference2 = self.Article(name='reference 2')
         article.references.append(reference2)
         self.session.commit()
 
         # update only the article and reference 1
-        article.name = "Updated article x2"
-        reference1.name = "Updated reference 1 x2"
+        article.name = 'Updated article x2'
+        reference1.name = 'Updated reference 1 x2'
         self.session.commit()
 
         assert len(article.versions[1].references) == 2
@@ -335,29 +332,29 @@ class TestManyToManySelfReferential(SQLModelTestCase):
 class TestManyToManySelfReferentialInOtherSchema(SQLModelTestCase):
     def create_models(self):
         class Article(self.Model):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
-            __table_args__ = {"schema": "other"}
+            __table_args__ = {'schema': 'other'}
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.Unicode(255))
 
         article_references = sa.Table(
-            "article_references",
+            'article_references',
             self.Model.metadata,
             sa.Column(
-                "referring_id",
+                'referring_id',
                 sa.Integer,
-                sa.ForeignKey("other.article.id"),
+                sa.ForeignKey('other.article.id'),
                 primary_key=True,
             ),
             sa.Column(
-                "referred_id",
+                'referred_id',
                 sa.Integer,
-                sa.ForeignKey("other.article.id"),
+                sa.ForeignKey('other.article.id'),
                 primary_key=True,
             ),
-            schema="other",
+            schema='other',
         )
 
         Article.references = sa.orm.relationship(
@@ -365,7 +362,7 @@ class TestManyToManySelfReferentialInOtherSchema(SQLModelTestCase):
             secondary=article_references,
             primaryjoin=Article.id == article_references.c.referring_id,
             secondaryjoin=Article.id == article_references.c.referred_id,
-            backref="cited_by",
+            backref='cited_by',
         )
 
         self.Article = Article
@@ -375,38 +372,38 @@ class TestManyToManySelfReferentialInOtherSchema(SQLModelTestCase):
 class ManyToManyRelationshipsInOtherSchemaTestCase(SQLModelTestCase):
     def create_models(self):
         class Article(self.Model):
-            __tablename__ = "article"
-            __versioned__ = {"base_classes": (self.Model,)}
-            __table_args__ = {"schema": "other"}
+            __tablename__ = 'article'
+            __versioned__ = {'base_classes': (self.Model,)}
+            __table_args__ = {'schema': 'other'}
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.Unicode(255))
 
         article_tag = sa.Table(
-            "article_tag",
+            'article_tag',
             self.Model.metadata,
             sa.Column(
-                "article_id",
+                'article_id',
                 sa.Integer,
-                sa.ForeignKey("other.article.id"),
+                sa.ForeignKey('other.article.id'),
                 primary_key=True,
             ),
             sa.Column(
-                "tag_id", sa.Integer, sa.ForeignKey("other.tag.id"), primary_key=True
+                'tag_id', sa.Integer, sa.ForeignKey('other.tag.id'), primary_key=True
             ),
-            schema="other",
+            schema='other',
         )
 
         class Tag(self.Model):
-            __tablename__ = "tag"
-            __versioned__ = {"base_classes": (self.Model,)}
-            __table_args__ = {"schema": "other"}
+            __tablename__ = 'tag'
+            __versioned__ = {'base_classes': (self.Model,)}
+            __table_args__ = {'schema': 'other'}
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.Unicode(255))
 
         Tag.articles = sa.orm.relationship(
-            Article, secondary=article_tag, backref="tags"
+            Article, secondary=article_tag, backref='tags'
         )
 
         self.Article = Article

--- a/tests/sqlmodel/relationships/test_non_versioned_classes.py
+++ b/tests/sqlmodel/relationships/test_non_versioned_classes.py
@@ -1,0 +1,101 @@
+from sqlmodel import Field, Relationship
+from tests.sqlmodel import SQLModelTestCase
+import sqlalchemy as sa
+
+
+class TestRelationshipToNonVersionedClass(SQLModelTestCase):
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+
+            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            articles: list["Article"] = Relationship(back_populates="author")
+
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(sa_type=sa.UnicodeText, default="")
+            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
+            author: User = Relationship(back_populates="articles")
+
+        self.Article = Article
+        self.User = User
+
+    def test_single_insert(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+
+        assert isinstance(article.versions[0].author, self.User)
+
+    def test_change_relationship(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        user = self.User(name=u'Some user')
+        self.session.add(article)
+        self.session.add(user)
+        self.session.commit()
+
+        assert article.versions.count() == 1
+        article.author = user
+        self.session.commit()
+        assert article.versions.count() == 2
+
+
+class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
+    def create_models(self):
+
+        class ArticleTagLink(self.Model, table=True):
+            __tablename__ = "article_tag"
+            article_id: int | None = Field(
+                default=None, foreign_key="article.id", primary_key=True
+            )
+            tag_id: int | None = Field(
+                default=None, foreign_key="tag.id", primary_key=True
+            )
+
+        class Article(self.Model, table=True):
+            __tablename__ = "article"
+            __versioned__ = {}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(max_length=255)
+            content: str = Field(default="")
+            tags: list["Tag"] = Relationship(
+                back_populates="articles", link_model=ArticleTagLink
+            )
+
+        class Tag(self.Model, table=True):
+            __tablename__ = "tag"
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(max_length=255)
+            articles: list[Article] = Relationship(
+                back_populates="tags", link_model=ArticleTagLink
+            )
+
+        self.Article = Article
+        self.Tag = Tag
+        self.ArticleTagLink = ArticleTagLink
+
+
+    def test_single_insert(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        tag = self.Tag(name=u'some tag')
+        article.tags.append(tag)
+        self.session.add(article)
+        self.session.commit()
+        assert len(article.versions[0].tags) == 1
+        assert isinstance(article.versions[0].tags[0], self.Tag)

--- a/tests/sqlmodel/relationships/test_non_versioned_classes.py
+++ b/tests/sqlmodel/relationships/test_non_versioned_classes.py
@@ -1,4 +1,5 @@
 from sqlmodel import Field, Relationship
+from typing import Union
 from tests.sqlmodel import SQLModelTestCase
 import sqlalchemy as sa
 
@@ -8,29 +9,33 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
         class User(self.Model, table=True):
             __tablename__ = 'user'
 
-            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            id: Union[int, None] = Field(
+                sa_type=sa.Integer, default=None, primary_key=True
+            )
             name: str = Field(sa_type=sa.Unicode(255))
-            articles: list["Article"] = Relationship(back_populates="author")
+            articles: list['Article'] = Relationship(back_populates='author')
 
         class Article(self.Model, table=True):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
-            description: str = Field(sa_type=sa.UnicodeText, default="")
-            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
-            author: User = Relationship(back_populates="articles")
+            description: str = Field(sa_type=sa.UnicodeText, default='')
+            author_id: Union[int, None] = Field(
+                sa_type=sa.Integer, foreign_key='user.id'
+            )
+            author: User = Relationship(back_populates='articles')
 
         self.Article = Article
         self.User = User
 
     def test_single_insert(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
-        user = self.User(name=u'Some user')
+        article.name = 'Some article'
+        article.content = 'Some content'
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
@@ -39,9 +44,9 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
 
     def test_change_relationship(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
-        user = self.User(name=u'Some user')
+        article.name = 'Some article'
+        article.content = 'Some content'
+        user = self.User(name='Some user')
         self.session.add(article)
         self.session.add(user)
         self.session.commit()
@@ -54,46 +59,44 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
 
 class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
     def create_models(self):
-
         class ArticleTagLink(self.Model, table=True):
-            __tablename__ = "article_tag"
-            article_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_tag'
+            article_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: int | None = Field(
-                default=None, foreign_key="tag.id", primary_key=True
+            tag_id: Union[int, None] = Field(
+                default=None, foreign_key='tag.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            tags: list["Tag"] = Relationship(
-                back_populates="articles", link_model=ArticleTagLink
+            content: str = Field(default='')
+            tags: list['Tag'] = Relationship(
+                back_populates='articles', link_model=ArticleTagLink
             )
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
-                back_populates="tags", link_model=ArticleTagLink
+                back_populates='tags', link_model=ArticleTagLink
             )
 
         self.Article = Article
         self.Tag = Tag
         self.ArticleTagLink = ArticleTagLink
 
-
     def test_single_insert(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
-        tag = self.Tag(name=u'some tag')
+        article.name = 'Some article'
+        article.content = 'Some content'
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()

--- a/tests/sqlmodel/relationships/test_one_to_one_relations.py
+++ b/tests/sqlmodel/relationships/test_one_to_one_relations.py
@@ -1,0 +1,85 @@
+from sqlmodel import Field, Relationship
+from tests import create_test_cases
+from tests.sqlmodel import SQLModelTestCase
+import sqlalchemy as sa
+
+
+class OneToOneRelationshipsTestCase(SQLModelTestCase):
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+            __versioned__ = {}
+
+            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            articles: list["Article"] = Relationship(back_populates="author")
+
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(sa_type=sa.UnicodeText, default="")
+            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
+            author: User = Relationship(back_populates="articles")
+
+        self.Article = Article
+        self.User = User
+
+    def test_single_insert(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+
+        assert article.versions[0].author
+
+    def test_multiple_relation_versions(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+        user.name = u'Someone else'
+        self.session.commit()
+
+        assert article.versions[0].author == user.versions[0]
+
+    def test_multiple_consecutive_inserts_and_removes(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+        user.name = u'Someone else'
+        self.session.commit()
+
+        article.name = u'Updated article'
+
+        article2 = self.Article(
+            name=u'Article 2',
+            content=""
+        )
+        self.session.add(article2)
+        article2.author = user
+        self.session.commit()
+
+        assert article2.versions[0].author == user.versions[1]
+
+    def test_replace(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+        other_user = self.User(name=u'Some other user')
+        article.author = other_user
+        self.session.commit()
+
+        assert article.versions[1].author == other_user.versions[0]
+
+
+create_test_cases(OneToOneRelationshipsTestCase)

--- a/tests/sqlmodel/relationships/test_one_to_one_relations.py
+++ b/tests/sqlmodel/relationships/test_one_to_one_relations.py
@@ -2,6 +2,7 @@ from sqlmodel import Field, Relationship
 from tests import create_test_cases
 from tests.sqlmodel import SQLModelTestCase
 import sqlalchemy as sa
+from typing import Union
 
 
 class OneToOneRelationshipsTestCase(SQLModelTestCase):
@@ -10,27 +11,31 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
             __tablename__ = 'user'
             __versioned__ = {}
 
-            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            id: Union[int, None] = Field(
+                sa_type=sa.Integer, default=None, primary_key=True
+            )
             name: str = Field(sa_type=sa.Unicode(255))
-            articles: list["Article"] = Relationship(back_populates="author")
+            articles: list['Article'] = Relationship(back_populates='author')
 
         class Article(self.Model, table=True):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
-            description: str = Field(sa_type=sa.UnicodeText, default="")
-            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
-            author: User = Relationship(back_populates="articles")
+            description: str = Field(sa_type=sa.UnicodeText, default='')
+            author_id: Union[int, None] = Field(
+                sa_type=sa.Integer, foreign_key='user.id'
+            )
+            author: User = Relationship(back_populates='articles')
 
         self.Article = Article
         self.User = User
 
     def test_single_insert(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
@@ -38,31 +43,28 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
         assert article.versions[0].author
 
     def test_multiple_relation_versions(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
-        user.name = u'Someone else'
+        user.name = 'Someone else'
         self.session.commit()
 
         assert article.versions[0].author == user.versions[0]
 
     def test_multiple_consecutive_inserts_and_removes(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
-        user.name = u'Someone else'
+        user.name = 'Someone else'
         self.session.commit()
 
-        article.name = u'Updated article'
+        article.name = 'Updated article'
 
-        article2 = self.Article(
-            name=u'Article 2',
-            content=""
-        )
+        article2 = self.Article(name='Article 2', content='')
         self.session.add(article2)
         article2.author = user
         self.session.commit()
@@ -70,12 +72,12 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
         assert article2.versions[0].author == user.versions[1]
 
     def test_replace(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
-        other_user = self.User(name=u'Some other user')
+        other_user = self.User(name='Some other user')
         article.author = other_user
         self.session.commit()
 

--- a/tests/sqlmodel/test_delete.py
+++ b/tests/sqlmodel/test_delete.py
@@ -1,0 +1,26 @@
+import sqlalchemy as sa
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestDelete(SQLModelTestCase):
+    def _delete(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        self.session.add(article)
+        self.session.commit()
+
+        self.session.delete(article)
+        self.session.commit()
+
+    def test_stores_operation_type(self):
+        self._delete()
+        versions = self.session.query(self.ArticleVersion).all()
+        assert versions[1].operation_type == 2
+
+    def test_creates_versions_on_delete(self):
+        self._delete()
+        versions = self.session.query(self.ArticleVersion).all()
+        assert len(versions) == 2
+        assert versions[1].name == u'Some article'
+        assert versions[1].content == u'Some content'

--- a/tests/sqlmodel/test_delete.py
+++ b/tests/sqlmodel/test_delete.py
@@ -5,8 +5,8 @@ from tests.sqlmodel import SQLModelTestCase
 class TestDelete(SQLModelTestCase):
     def _delete(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
+        article.name = 'Some article'
+        article.content = 'Some content'
         self.session.add(article)
         self.session.commit()
 
@@ -15,12 +15,16 @@ class TestDelete(SQLModelTestCase):
 
     def test_stores_operation_type(self):
         self._delete()
-        versions = self.session.query(self.ArticleVersion).all()
-        assert versions[1].operation_type == 2
+        versions = self.session.exec(
+            sa.select(self.ArticleVersion).order_by(
+                sa.asc(self.ArticleVersion.transaction_id)
+            )
+        ).all()
+        assert versions[1][0].operation_type == 2
 
     def test_creates_versions_on_delete(self):
         self._delete()
         versions = self.session.query(self.ArticleVersion).all()
         assert len(versions) == 2
-        assert versions[1].name == u'Some article'
-        assert versions[1].content == u'Some content'
+        assert versions[1].name == 'Some article'
+        assert versions[1].content == 'Some content'

--- a/tests/sqlmodel/test_insert.py
+++ b/tests/sqlmodel/test_insert.py
@@ -1,0 +1,67 @@
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy_continuum import versioning_manager
+
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestInsertSQLModel(SQLModelTestCase):
+    def _insert(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+        return article
+
+    def test_insert_creates_version(self):
+        article = self._insert()
+        version = list(article.versions)[-1]
+        assert version.name == u'Some article'
+        assert version.content == u'Some content'
+        assert version.transaction.id == version.transaction_id
+
+    def test_stores_operation_type(self):
+        article = self._insert()
+        assert article.versions[0].operation_type == 0
+
+    def test_multiple_consecutive_flushes(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.flush()
+        article2 = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article2)
+        self.session.flush()
+        self.session.commit()
+        assert article.versions.count() == 1
+        assert article2.versions.count() == 1
+
+
+class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
+    def create_models(self):
+        self.Model = sqlmodel.SQLModel
+        class TextItem(self.Model, table=True):
+            __tablename__ = 'text_item'
+            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            name: str = sqlmodel.Field(sa.Unicode(255))
+
+        class Tag(self.Model, table=True):
+            __tablename__ = 'tag'
+            __versioned__ = {}
+            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            name: str = sqlmodel.Field(sa.Unicode(255))
+
+        self.TextItem = TextItem
+        self.Tag = Tag
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
+        self.Model.metadata.remove(self.TextItem.__table__)
+        self.Model.metadata.remove(self.Tag.__table__)
+
+    def test_does_not_create_transaction(self):
+        item = self.TextItem(name="test")
+        self.session.add(item)
+        self.session.commit()
+
+        assert self.session.query(
+            versioning_manager.transaction_cls
+        ).count() == 0

--- a/tests/sqlmodel/test_insert.py
+++ b/tests/sqlmodel/test_insert.py
@@ -1,13 +1,13 @@
 import sqlalchemy as sa
 import sqlmodel
 from sqlalchemy_continuum import versioning_manager
-
+from typing import Union
 from tests.sqlmodel import SQLModelTestCase
 
 
 class TestInsertSQLModel(SQLModelTestCase):
     def _insert(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         return article
@@ -15,8 +15,8 @@ class TestInsertSQLModel(SQLModelTestCase):
     def test_insert_creates_version(self):
         article = self._insert()
         version = list(article.versions)[-1]
-        assert version.name == u'Some article'
-        assert version.content == u'Some content'
+        assert version.name == 'Some article'
+        assert version.content == 'Some content'
         assert version.transaction.id == version.transaction_id
 
     def test_stores_operation_type(self):
@@ -24,10 +24,10 @@ class TestInsertSQLModel(SQLModelTestCase):
         assert article.versions[0].operation_type == 0
 
     def test_multiple_consecutive_flushes(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.flush()
-        article2 = self.Article(name=u"Some article", content=u"Some content")
+        article2 = self.Article(name='Some article', content='Some content')
         self.session.add(article2)
         self.session.flush()
         self.session.commit()
@@ -38,15 +38,16 @@ class TestInsertSQLModel(SQLModelTestCase):
 class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
     def create_models(self):
         self.Model = sqlmodel.SQLModel
+
         class TextItem(self.Model, table=True):
             __tablename__ = 'text_item'
-            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            id: Union[int, None] = sqlmodel.Field(default=None, primary_key=True)
             name: str = sqlmodel.Field(sa.Unicode(255))
 
         class Tag(self.Model, table=True):
             __tablename__ = 'tag'
             __versioned__ = {}
-            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            id: Union[int, None] = sqlmodel.Field(default=None, primary_key=True)
             name: str = sqlmodel.Field(sa.Unicode(255))
 
         self.TextItem = TextItem
@@ -58,10 +59,8 @@ class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
         self.Model.metadata.remove(self.Tag.__table__)
 
     def test_does_not_create_transaction(self):
-        item = self.TextItem(name="test")
+        item = self.TextItem(name='test')
         self.session.add(item)
         self.session.commit()
 
-        assert self.session.query(
-            versioning_manager.transaction_cls
-        ).count() == 0
+        assert self.session.query(versioning_manager.transaction_cls).count() == 0

--- a/tests/sqlmodel/test_revert.py
+++ b/tests/sqlmodel/test_revert.py
@@ -1,0 +1,166 @@
+from pytest import raises
+import sqlalchemy as sa
+from sqlmodel import Field, Relationship
+from sqlalchemy_continuum.reverter import Reverter, ReverterException
+
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestReverter(SQLModelTestCase):
+    def test_raises_exception_for_unknown_relations(self):
+        article = self.Article()
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+
+        self.session.commit()
+        version = article.versions[0]
+
+        with raises(ReverterException):
+            Reverter(version, relations=['unknown_relation'])
+
+
+class RevertTestCase(SQLModelTestCase):
+    def add_article(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+        return article
+
+    def test_simple_revert(self):
+        article = self.add_article()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        self.session.commit()
+        self.session.refresh(article)
+        article.versions[0].revert()
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+
+    def test_revert_deleted_model(self):
+        article = self.add_article()
+        old_article_id = article.id
+        version = article.versions[0]
+        self.session.delete(article)
+        self.session.commit()
+        version.revert()
+        assert article.id == old_article_id
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+
+    def test_revert_deletion(self):
+        article = self.add_article()
+        old_article_id = article.id
+        version = article.versions[0]
+        self.session.delete(article)
+        self.session.commit()
+        version.revert()
+        self.session.commit()
+        assert self.session.query(self.Article).count() == 1
+        article = self.session.query(self.Article).get(old_article_id)
+
+        assert version.next.next
+
+        version.next.revert()
+        self.session.commit()
+        assert not self.session.query(self.Article).get(old_article_id)
+
+    def test_revert_version_with_one_to_many_relation(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        article.tags.append(self.Tag(name=u'some tag'))
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        article.tags = []
+        self.session.commit()
+        self.session.refresh(article)
+        assert article.tags == []
+        assert len(article.versions[0].tags) == 1
+        assert article.versions[0].tags[0].article
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+        assert len(article.tags) == 1
+        assert article.tags[0].name == u'some tag'
+
+    def test_with_one_to_many_relation_delete_newly_added(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        article.tags.append(self.Tag(name=u'some tag'))
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        article.tags.append(self.Tag(name=u'some other tag'))
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        assert len(article.tags) == 2
+        assert len(article.versions[0].tags) == 1
+        assert article.versions[0].tags[0].article
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+        assert len(article.tags) == 1
+        assert article.tags[0].name == u'some tag'
+
+    def test_with_one_to_many_relation_resurrect_deleted(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        tag = self.Tag(name=u'some other tag')
+        article.tags.append(self.Tag(name=u'some tag'))
+        article.tags.append(tag)
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.tags.remove(tag)
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        assert len(article.tags) == 1
+        assert len(article.versions[0].tags) == 2
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+        assert len(article.tags) == 2
+        assert article.tags[0].name == u'some tag'
+
+
+class TestRevertWithDefaultVersioningStrategy(RevertTestCase):
+    pass
+
+
+class TestRevertWithValidityVersioningStrategy(RevertTestCase):
+    versioning_strategy = 'validity'
+
+
+class TestRevertWithCustomTransactionColumn(RevertTestCase):
+    transaction_column_name = 'tx_id'
+
+
+class TestRevertWithColumnExclusion(RevertTestCase):
+    def create_models(self):
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {
+                'exclude': ['description']
+            }
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(sa_type=sa.UnicodeText, default=None, nullable=True)
+            tags: list["Tag"] = Relationship(back_populates="article")
+
+        class Tag(self.Model, table=True):
+            __tablename__ = 'tag'
+            __versioned__ = {}
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            article_id: int | None = Field(default=None, foreign_key="article.id")
+            article: Article = Relationship(back_populates="tags")
+
+        self.Article = Article
+        self.Tag = Tag

--- a/tests/sqlmodel/test_revert.py
+++ b/tests/sqlmodel/test_revert.py
@@ -4,12 +4,13 @@ from sqlmodel import Field, Relationship
 from sqlalchemy_continuum.reverter import Reverter, ReverterException
 
 from tests.sqlmodel import SQLModelTestCase
+from typing import Union
 
 
 class TestReverter(SQLModelTestCase):
     def test_raises_exception_for_unknown_relations(self):
         article = self.Article()
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
 
         self.session.commit()
@@ -21,20 +22,20 @@ class TestReverter(SQLModelTestCase):
 
 class RevertTestCase(SQLModelTestCase):
     def add_article(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         return article
 
     def test_simple_revert(self):
         article = self.add_article()
-        article.name = u'Updated name'
-        article.content = u'Updated content'
+        article.name = 'Updated name'
+        article.content = 'Updated content'
         self.session.commit()
         self.session.refresh(article)
         article.versions[0].revert()
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
 
     def test_revert_deleted_model(self):
         article = self.add_article()
@@ -44,8 +45,8 @@ class RevertTestCase(SQLModelTestCase):
         self.session.commit()
         version.revert()
         assert article.id == old_article_id
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
 
     def test_revert_deletion(self):
         article = self.add_article()
@@ -65,12 +66,12 @@ class RevertTestCase(SQLModelTestCase):
         assert not self.session.query(self.Article).get(old_article_id)
 
     def test_revert_version_with_one_to_many_relation(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
-        article.tags.append(self.Tag(name=u'some tag'))
+        article = self.Article(name='Some article', content='Some content')
+        article.tags.append(self.Tag(name='some tag'))
         self.session.add(article)
         self.session.commit()
-        article.name = u'Updated name'
-        article.content = u'Updated content'
+        article.name = 'Updated name'
+        article.content = 'Updated content'
         article.tags = []
         self.session.commit()
         self.session.refresh(article)
@@ -80,19 +81,19 @@ class RevertTestCase(SQLModelTestCase):
         article.versions[0].revert(relations=['tags'])
         self.session.commit()
 
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
         assert len(article.tags) == 1
-        assert article.tags[0].name == u'some tag'
+        assert article.tags[0].name == 'some tag'
 
     def test_with_one_to_many_relation_delete_newly_added(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
-        article.tags.append(self.Tag(name=u'some tag'))
+        article = self.Article(name='Some article', content='Some content')
+        article.tags.append(self.Tag(name='some tag'))
         self.session.add(article)
         self.session.commit()
-        article.name = u'Updated name'
-        article.content = u'Updated content'
-        article.tags.append(self.Tag(name=u'some other tag'))
+        article.name = 'Updated name'
+        article.content = 'Updated content'
+        article.tags.append(self.Tag(name='some other tag'))
         self.session.add(article)
         self.session.commit()
         self.session.refresh(article)
@@ -102,19 +103,19 @@ class RevertTestCase(SQLModelTestCase):
         article.versions[0].revert(relations=['tags'])
         self.session.commit()
 
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
         assert len(article.tags) == 1
-        assert article.tags[0].name == u'some tag'
+        assert article.tags[0].name == 'some tag'
 
     def test_with_one_to_many_relation_resurrect_deleted(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
-        tag = self.Tag(name=u'some other tag')
-        article.tags.append(self.Tag(name=u'some tag'))
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some other tag')
+        article.tags.append(self.Tag(name='some tag'))
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
-        article.name = u'Updated name'
+        article.name = 'Updated name'
         article.tags.remove(tag)
         self.session.add(article)
         self.session.commit()
@@ -124,7 +125,7 @@ class RevertTestCase(SQLModelTestCase):
         article.versions[0].revert(relations=['tags'])
         self.session.commit()
         assert len(article.tags) == 2
-        assert article.tags[0].name == u'some tag'
+        assert article.tags[0].name == 'some tag'
 
 
 class TestRevertWithDefaultVersioningStrategy(RevertTestCase):
@@ -143,15 +144,15 @@ class TestRevertWithColumnExclusion(RevertTestCase):
     def create_models(self):
         class Article(self.Model, table=True):
             __tablename__ = 'article'
-            __versioned__ = {
-                'exclude': ['description']
-            }
+            __versioned__ = {'exclude': ['description']}
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
-            description: str = Field(sa_type=sa.UnicodeText, default=None, nullable=True)
-            tags: list["Tag"] = Relationship(back_populates="article")
+            description: str = Field(
+                sa_type=sa.UnicodeText, default=None, nullable=True
+            )
+            tags: list['Tag'] = Relationship(back_populates='article')
 
         class Tag(self.Model, table=True):
             __tablename__ = 'tag'
@@ -159,8 +160,8 @@ class TestRevertWithColumnExclusion(RevertTestCase):
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
-            article_id: int | None = Field(default=None, foreign_key="article.id")
-            article: Article = Relationship(back_populates="tags")
+            article_id: Union[int, None] = Field(default=None, foreign_key='article.id')
+            article: Article = Relationship(back_populates='tags')
 
         self.Article = Article
         self.Tag = Tag

--- a/tests/sqlmodel/test_transaction.py
+++ b/tests/sqlmodel/test_transaction.py
@@ -1,0 +1,89 @@
+import sqlalchemy as sa
+from sqlmodel import AutoString, Field
+from sqlalchemy_continuum import versioning_manager
+from tests.sqlmodel import SQLModelTestCase
+from sqlalchemy_continuum.plugins import TransactionMetaPlugin
+
+
+
+class TestTransaction(SQLModelTestCase):
+    def setup_method(self, method):
+        SQLModelTestCase.setup_method(self, method)
+        self.article = self.Article(name= u'Some article', content=u'Some content')
+        self.article.tags.append(self.Tag(name=u'Some tag'))
+        self.session.add(self.article)
+        self.session.commit()
+
+    def test_relationships(self):
+        assert self.article.versions[0].transaction
+
+    def test_only_saves_transaction_if_actual_modifications(self):
+        self.article.name = u'Some article'
+        self.session.commit()
+        self.article.name = u'Some article'
+        self.session.commit()
+        assert self.session.query(
+            versioning_manager.transaction_cls
+        ).count() == 1
+
+    def test_repr(self):
+        transaction = self.session.query(
+            versioning_manager.transaction_cls
+        ).first()
+        assert (
+            '<Transaction id=%d, issued_at=%r>' % (
+                transaction.id,
+                transaction.issued_at
+            ) ==
+            repr(transaction)
+        )
+
+    def test_changed_entities(self):
+        article_v0 = self.article.versions[0]
+        transaction = article_v0.transaction
+        assert transaction.changed_entities == {
+            self.ArticleVersion: [article_v0],
+            self.TagVersion: [self.article.tags[0].versions[0]],
+        }
+
+
+# Check that the tests pass without TransactionChangesPlugin
+class TestTransactionWithoutChangesPlugin(TestTransaction):
+    plugins = [TransactionMetaPlugin()]
+
+
+class TestAssigningUserClass(SQLModelTestCase):
+    user_cls = 'User'
+
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+            __versioned__ = {}
+            id: str | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+
+        self.User = User
+
+    def test_copies_primary_key_type_from_user_class(self):
+        attr = versioning_manager.transaction_cls.user_id
+        assert isinstance(attr.property.columns[0].type, AutoString)
+
+
+class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
+    user_cls = 'User'
+
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+            __versioned__ = {}
+            __table_args__ = {'schema': 'other'}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+
+        self.User = User
+
+    def test_can_build_transaction_model(self):
+        # If create_models didn't crash this should be good
+        pass
+

--- a/tests/sqlmodel/test_transaction.py
+++ b/tests/sqlmodel/test_transaction.py
@@ -3,14 +3,14 @@ from sqlmodel import AutoString, Field
 from sqlalchemy_continuum import versioning_manager
 from tests.sqlmodel import SQLModelTestCase
 from sqlalchemy_continuum.plugins import TransactionMetaPlugin
-
+from typing import Union
 
 
 class TestTransaction(SQLModelTestCase):
     def setup_method(self, method):
         SQLModelTestCase.setup_method(self, method)
-        self.article = self.Article(name= u'Some article', content=u'Some content')
-        self.article.tags.append(self.Tag(name=u'Some tag'))
+        self.article = self.Article(name='Some article', content='Some content')
+        self.article.tags.append(self.Tag(name='Some tag'))
         self.session.add(self.article)
         self.session.commit()
 
@@ -18,25 +18,18 @@ class TestTransaction(SQLModelTestCase):
         assert self.article.versions[0].transaction
 
     def test_only_saves_transaction_if_actual_modifications(self):
-        self.article.name = u'Some article'
+        self.article.name = 'Some article'
         self.session.commit()
-        self.article.name = u'Some article'
+        self.article.name = 'Some article'
         self.session.commit()
-        assert self.session.query(
-            versioning_manager.transaction_cls
-        ).count() == 1
+        assert self.session.query(versioning_manager.transaction_cls).count() == 1
 
     def test_repr(self):
-        transaction = self.session.query(
-            versioning_manager.transaction_cls
-        ).first()
-        assert (
-            '<Transaction id=%d, issued_at=%r>' % (
-                transaction.id,
-                transaction.issued_at
-            ) ==
-            repr(transaction)
-        )
+        transaction = self.session.query(versioning_manager.transaction_cls).first()
+        assert '<Transaction id=%d, issued_at=%r>' % (
+            transaction.id,
+            transaction.issued_at,
+        ) == repr(transaction)
 
     def test_changed_entities(self):
         article_v0 = self.article.versions[0]
@@ -59,7 +52,7 @@ class TestAssigningUserClass(SQLModelTestCase):
         class User(self.Model, table=True):
             __tablename__ = 'user'
             __versioned__ = {}
-            id: str | None = Field(default=None, primary_key=True)
+            id: Union[str, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
 
         self.User = User
@@ -78,7 +71,7 @@ class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
             __versioned__ = {}
             __table_args__ = {'schema': 'other'}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[str, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
 
         self.User = User
@@ -86,4 +79,3 @@ class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
     def test_can_build_transaction_model(self):
         # If create_models didn't crash this should be good
         pass
-

--- a/tests/sqlmodel/test_update.py
+++ b/tests/sqlmodel/test_update.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestUpdateSQLModel(SQLModelTestCase):
+    def test_creates_versions_on_update(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+
+        self.session.commit()
+        self.session.refresh(article)
+        version = list(article.versions)[-1]
+        assert version.name == u'Updated name'
+        assert version.content == u'Updated content'
+        assert version.transaction.id == version.transaction_id
+
+    def test_partial_update(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.content = u'Updated content'
+
+        self.session.commit()
+        self.session.refresh(article)
+        version = list(article.versions)[-1]
+        assert version.name == u'Some article'
+        assert version.content == u'Updated content'
+        assert version.transaction.id == version.transaction_id
+
+    def test_update_with_same_values(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        article.name = u'Some article'
+
+        self.session.commit()
+        assert article.versions.count() == 1
+
+    def test_stores_operation_type(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = u'Some other article'
+
+        self.session.commit()
+        assert list(article.versions)[-1].operation_type == 1
+
+    def test_multiple_updates_within_same_transaction(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.content = u'Updated content'
+        self.session.flush()
+        article.content = u'Updated content 2'
+        self.session.commit()
+        assert article.versions.count() == 2
+        version = list(article.versions)[-1]
+        assert version.name == u'Some article'
+        assert version.content == u'Updated content 2'
+
+
+class TestUpdateWithDefaultValuesSQLModel(SQLModelTestCase):
+    def create_models(self):
+        self.Model = SQLModel
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {
+            }
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            updated_at: datetime = Field(sa_type=sa.DateTime, sa_column_kwargs={"server_default": sa.func.now()})
+            is_editable: bool = Field()
+
+        self.Article = Article
+
+    def test_update_with_default_values(self):
+        article = self.Article(name=u"Some article", is_editable=False)
+        self.session.add(article)
+        self.session.commit()
+
+        article.is_editable = True
+        self.session.commit()
+        article = list(article.versions)[-1]
+        assert article.name == u'Some article'

--- a/tests/sqlmodel/test_update.py
+++ b/tests/sqlmodel/test_update.py
@@ -3,93 +3,96 @@ from datetime import datetime
 import sqlalchemy as sa
 from sqlmodel import Field, SQLModel
 from tests.sqlmodel import SQLModelTestCase
+from typing import Union
 
 
 class TestUpdateSQLModel(SQLModelTestCase):
     def test_creates_versions_on_update(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.name = u'Updated name'
-        article.content = u'Updated content'
+        article.name = 'Updated name'
+        article.content = 'Updated content'
 
         self.session.commit()
         self.session.refresh(article)
         version = list(article.versions)[-1]
-        assert version.name == u'Updated name'
-        assert version.content == u'Updated content'
+        assert version.name == 'Updated name'
+        assert version.content == 'Updated content'
         assert version.transaction.id == version.transaction_id
 
     def test_partial_update(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.content = u'Updated content'
+        article.content = 'Updated content'
 
         self.session.commit()
         self.session.refresh(article)
         version = list(article.versions)[-1]
-        assert version.name == u'Some article'
-        assert version.content == u'Updated content'
+        assert version.name == 'Some article'
+        assert version.content == 'Updated content'
         assert version.transaction.id == version.transaction_id
 
     def test_update_with_same_values(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         self.session.refresh(article)
-        article.name = u'Some article'
+        article.name = 'Some article'
 
         self.session.commit()
         assert article.versions.count() == 1
 
     def test_stores_operation_type(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.name = u'Some other article'
+        article.name = 'Some other article'
 
         self.session.commit()
         assert list(article.versions)[-1].operation_type == 1
 
     def test_multiple_updates_within_same_transaction(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.content = u'Updated content'
+        article.content = 'Updated content'
         self.session.flush()
-        article.content = u'Updated content 2'
+        article.content = 'Updated content 2'
         self.session.commit()
         assert article.versions.count() == 2
         version = list(article.versions)[-1]
-        assert version.name == u'Some article'
-        assert version.content == u'Updated content 2'
+        assert version.name == 'Some article'
+        assert version.content == 'Updated content 2'
 
 
 class TestUpdateWithDefaultValuesSQLModel(SQLModelTestCase):
     def create_models(self):
         self.Model = SQLModel
+
         class Article(self.Model, table=True):
             __tablename__ = 'article'
-            __versioned__ = {
-            }
-            id: int | None = Field(default=None, primary_key=True)
+            __versioned__ = {}
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
-            updated_at: datetime = Field(sa_type=sa.DateTime, sa_column_kwargs={"server_default": sa.func.now()})
+            updated_at: datetime = Field(
+                sa_type=sa.DateTime, sa_column_kwargs={'server_default': sa.func.now()}
+            )
             is_editable: bool = Field()
 
         self.Article = Article
 
     def test_update_with_default_values(self):
-        article = self.Article(name=u"Some article", is_editable=False)
+        article = self.Article(name='Some article', is_editable=False)
         self.session.add(article)
         self.session.commit()
 
         article.is_editable = True
         self.session.commit()
         article = list(article.versions)[-1]
-        assert article.name == u'Some article'
+        assert article.name == 'Some article'

--- a/tests/sqlmodel/test_versions.py
+++ b/tests/sqlmodel/test_versions.py
@@ -1,0 +1,24 @@
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestVersions(SQLModelTestCase):
+    def test_versions_ordered_by_transaction_id(self):
+        names = [
+            u'Some article',
+            u'Update 1 article',
+            u'Update 2 article',
+            u'Update 3 article',
+        ]
+
+        article = self.Article(name=names[0], content="")
+        self.session.add(article)
+        self.session.commit()
+        article.name = names[1]
+        self.session.commit()
+        article.name = names[2]
+        self.session.commit()
+        article.name = names[3]
+        self.session.commit()
+
+        for index, name in enumerate(names):
+            assert article.versions[index].name == name

--- a/tests/sqlmodel/test_versions.py
+++ b/tests/sqlmodel/test_versions.py
@@ -4,13 +4,13 @@ from tests.sqlmodel import SQLModelTestCase
 class TestVersions(SQLModelTestCase):
     def test_versions_ordered_by_transaction_id(self):
         names = [
-            u'Some article',
-            u'Update 1 article',
-            u'Update 2 article',
-            u'Update 3 article',
+            'Some article',
+            'Update 1 article',
+            'Update 2 article',
+            'Update 3 article',
         ]
 
-        article = self.Article(name=names[0], content="")
+        article = self.Article(name=names[0], content='')
         self.session.add(article)
         self.session.commit()
         article.name = names[1]


### PR DESCRIPTION
Add support for models configured via https://github.com/fastapi/sqlmodel

As of current `SQLModel`/`SQLAlchemy`/`SQLAlchemy-Continuum` API, there is no need to depend on `SQLModel` to support it, as only change needed is to make `SQLAlchemy-Continuum` to pull `SQLAlchemy` class registry from different attribute for `SQLModel` derived models as compared to pure `SQLAlchemy` defined ones.

The `base_classes` parameter for versioned models does not work with `SQLModel`, `pydantic` metaclass magic fails for version model classes created with `base_classes` passed, because they are lacking `__module__`  attribute somehow, leading to `AttributeError` inside pydantic meta methods. Since I do not use `base_classes` in my projects, I decided not to put effort to support it in this patch, but future support might need changes in either `SQLModel` or `pydantic`.

Otherwise, most of stuff seem to work well, ported CRUD and relationships tests to run with `SQLModel` defined models as part of this PR.

I'd like to say thanks to https://github.com/AlePiccin who suggested the idea behind this PR implementation here: https://github.com/kvesteri/sqlalchemy-continuum/issues/271#issuecomment-2521189305