### PR TITLE
Added efficient version query utilities and composite indexes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,6 +113,12 @@ Here is a full list of configuration options:
 * strategy (default: 'validity')
     The versioning strategy to use. Either 'validity' or 'subquery'
 
+* create_composite_index (default: True)
+    Whether to automatically create composite indexes on version tables for efficient version queries.
+    The composite index is created on ``(primary_key_columns, transaction_id DESC)`` which dramatically
+    speeds up common query patterns like finding a specific version of an entity. For validity strategy,
+    an additional index on ``(primary_key_columns, transaction_id, end_transaction_id)`` is also created.
+
 
 Example
 ::

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -71,3 +71,184 @@ PropertyModTrackerPlugin.
     ArticleVersion = version_class(Article)
 
     session.query(ArticleHistory).filter(ArticleVersion.name_mod).all()
+
+
+Efficient Version Queries
+=========================
+
+SQLAlchemy-Continuum provides several methods for efficiently querying version history
+without incurring N+1 query problems.
+
+
+Querying version at a specific transaction
+------------------------------------------
+
+The ``version_at`` class method efficiently retrieves the version that was active
+at a specific transaction. This is much faster than iterating through versions manually.
+
+::
+
+    ArticleVersion = version_class(Article)
+
+    # Get the version of Article #5 that was active at transaction #100
+    version = ArticleVersion.version_at(
+        session,
+        {'id': 5},
+        transaction_id=100
+    )
+
+For the validity strategy (default), this uses an efficient range query::
+
+    WHERE transaction_id <= 100
+      AND (end_transaction_id > 100 OR end_transaction_id IS NULL)
+
+For the subquery strategy, it finds the version with the highest transaction_id <= target.
+
+
+Batch fetching all versions
+---------------------------
+
+When you need to iterate through version history, avoid the N+1 query problem by
+using ``all_versions`` instead of repeatedly accessing ``.previous`` or ``.next``:
+
+::
+
+    ArticleVersion = version_class(Article)
+
+    # Fetch all versions for Article #5 in a single query
+    versions = ArticleVersion.all_versions(
+        session,
+        {'id': 5},
+        limit=10,      # Optional: limit to 10 most recent
+        desc=True,     # Newest first (default)
+        link=True      # Pre-populate previous/next caches (default)
+    )
+
+    # Now iteration doesn't trigger additional queries
+    for version in versions:
+        print(version.changeset)
+        print(version.previous)  # Uses cached value, no additional query!
+
+
+When ``link=True`` (the default), the returned versions will have their ``.previous``
+and ``.next`` properties pre-populated from the fetched results. This means accessing
+these properties won't trigger additional database queries.
+
+**Anti-pattern to avoid:**
+
+::
+
+    # BAD: This triggers N queries for N versions!
+    version = article.versions[-1]
+    while version:
+        process(version)
+        version = version.previous  # Each call is a separate query
+
+**Recommended pattern:**
+
+::
+
+    # GOOD: Single query, then iterate in memory
+    versions = ArticleVersion.all_versions(
+        session,
+        {'id': article.id}
+    )
+    for version in versions:
+        process(version)
+
+
+Index Recommendations
+=====================
+
+SQLAlchemy-Continuum automatically creates several indexes on version tables.
+Understanding these indexes helps you write efficient queries.
+
+
+Automatic Indexes
+-----------------
+
+The following indexes are created automatically:
+
+* ``transaction_id`` - Primary key index (always present)
+* ``end_transaction_id`` - For validity strategy (enables efficient range queries)
+* ``operation_type`` - For filtering INSERT/UPDATE/DELETE operations
+
+Starting with version 1.6.0, composite indexes are also created by default:
+
+* ``(primary_keys, transaction_id DESC)`` - For efficient entity version lookups
+* ``(primary_keys, transaction_id, end_transaction_id)`` - For validity strategy temporal queries
+
+These composite indexes dramatically speed up the most common query patterns.
+
+
+Disabling Composite Indexes
+---------------------------
+
+If you need to disable automatic composite index creation (e.g., for migration compatibility),
+you can set the ``create_composite_index`` option to ``False``::
+
+    make_versioned(options={'create_composite_index': False})
+
+Or per-model::
+
+    class Article(Base):
+        __versioned__ = {
+            'create_composite_index': False
+        }
+
+
+Recommended Additional Indexes
+------------------------------
+
+Depending on your query patterns, you may want to add these additional indexes:
+
+**For queries filtering by operation type and entity:**
+
+::
+
+    from sqlalchemy import Index
+
+    Index(
+        'ix_article_version_id_operation',
+        ArticleVersion.id,
+        ArticleVersion.operation_type,
+        ArticleVersion.transaction_id
+    )
+
+**For queries joining with Transaction table on issued_at:**
+
+If you frequently query versions by timestamp (e.g., "give me the version as of 2023-01-01"),
+ensure you have an index on ``Transaction.issued_at``::
+
+    Index('ix_transaction_issued_at', Transaction.issued_at.desc())
+
+**For PropertyModTrackerPlugin queries:**
+
+If you use PropertyModTrackerPlugin and frequently query for versions where specific
+fields changed, consider partial indexes::
+
+    # PostgreSQL partial index example
+    Index(
+        'ix_article_version_name_mod',
+        ArticleVersion.id,
+        postgresql_where=ArticleVersion.name_mod.is_(True)
+    )
+
+
+Query Performance Tips
+----------------------
+
+1. **Use the validity strategy** (default) for read-heavy workloads. It enables
+   O(log N) version lookups via direct equality conditions instead of correlated subqueries.
+
+2. **Batch fetch versions** using ``all_versions()`` instead of iterating with ``.previous``/``.next``.
+
+3. **Add composite indexes** on ``(entity_pk, transaction_id)`` for your most-queried version tables.
+
+4. **Use LIMIT** when you only need recent versions::
+
+       ArticleVersion.all_versions(session, {'id': 5}, limit=10)
+
+5. **Avoid relationship traversal** on version objects when possible. Relationship queries
+   on versions generate complex subqueries. If you need related data, fetch from the
+   parent object first or use explicit joins.

--- a/sqlalchemy_continuum/fetcher.py
+++ b/sqlalchemy_continuum/fetcher.py
@@ -1,9 +1,12 @@
 import operator
+from typing import List, Optional, TypeVar
 
 import sqlalchemy as sa
 from ._compat import get_primary_keys, identity
 
 from .utils import end_tx_column_name, tx_column_name
+
+T = TypeVar('T')
 
 
 def parent_identity(obj_or_class):
@@ -51,6 +54,101 @@ class VersionObjectFetcher:
         None.
         """
         return self.next_query(obj).first()
+
+    def version_at(self, session, version_cls, primary_key_values: dict, transaction_id: int):
+        """
+        Returns the version that was active at the given transaction_id.
+
+        This is an efficient query that finds the version where:
+        - transaction_id <= target_transaction_id
+        - end_transaction_id > target_transaction_id OR end_transaction_id IS NULL
+
+        For subquery strategy, it finds the version with the highest transaction_id
+        that is <= target_transaction_id.
+
+        :param session: SQLAlchemy session
+        :param version_cls: The version class to query
+        :param primary_key_values: Dict mapping primary key column names to values
+        :param transaction_id: The transaction ID to query at
+        :returns: The version object active at that transaction, or None
+        """
+        raise NotImplementedError("Subclasses must implement version_at")
+
+    def all_versions(
+        self,
+        session,
+        version_cls,
+        primary_key_values: dict,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        desc: bool = True,
+    ) -> List:
+        """
+        Efficiently fetch all versions for an entity in a single query.
+
+        This avoids N+1 queries when iterating through version history
+        by fetching all versions at once, sorted by transaction_id.
+
+        :param session: SQLAlchemy session
+        :param version_cls: The version class to query
+        :param primary_key_values: Dict mapping primary key column names to values
+        :param limit: Maximum number of versions to return (None for all)
+        :param offset: Number of versions to skip
+        :param desc: If True, return newest versions first
+        :returns: List of version objects
+        """
+        tx_col = tx_column_name(version_cls)
+
+        query = session.query(version_cls)
+
+        # Add primary key filters
+        for pk_name, pk_value in primary_key_values.items():
+            query = query.filter(getattr(version_cls, pk_name) == pk_value)
+
+        # Order by transaction_id
+        if desc:
+            query = query.order_by(getattr(version_cls, tx_col).desc())
+        else:
+            query = query.order_by(getattr(version_cls, tx_col).asc())
+
+        # Apply pagination
+        if offset:
+            query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
+
+        return query.all()
+
+    def link_versions(self, versions: List, desc: bool = True) -> List:
+        """
+        Link a list of versions by setting _previous_cache and _next_cache
+        attributes to avoid additional queries when accessing .previous or .next.
+
+        This is useful after calling all_versions() to pre-populate the
+        navigation cache.
+
+        :param versions: List of version objects (must be from same entity)
+        :param desc: If True, versions are ordered newest-first
+        :returns: The same list with _previous_cache and _next_cache populated
+        """
+        if not versions:
+            return versions
+
+        # If descending order: versions[0] is newest, versions[-1] is oldest
+        # If ascending order: versions[0] is oldest, versions[-1] is newest
+        for i, version in enumerate(versions):
+            if desc:
+                # In descending order: next is at lower index, previous is at higher index
+                version._next_cache = versions[i - 1] if i > 0 else None
+                version._previous_cache = versions[i + 1] if i < len(versions) - 1 else None
+            else:
+                # In ascending order: previous is at lower index, next is at higher index
+                version._previous_cache = versions[i - 1] if i > 0 else None
+                version._next_cache = versions[i + 1] if i < len(versions) - 1 else None
+            # Mark cache as populated so .previous/.next use cached values
+            version._cache_populated = True
+
+        return versions
 
     def _transaction_id_subquery(self, obj, next_or_prev='next', alias=None):
         if next_or_prev == 'next':
@@ -143,6 +241,40 @@ class SubqueryFetcher(VersionObjectFetcher):
         """
         return self._next_prev_query(obj, 'next')
 
+    def version_at(self, session, version_cls, primary_key_values: dict, transaction_id: int):
+        """
+        Returns the version that was active at the given transaction_id.
+
+        For subquery strategy, finds the version with the highest transaction_id
+        that is <= target_transaction_id.
+
+        :param session: SQLAlchemy session
+        :param version_cls: The version class to query
+        :param primary_key_values: Dict mapping primary key column names to values
+        :param transaction_id: The transaction ID to query at
+        :returns: The version object active at that transaction, or None
+        """
+        tx_col = tx_column_name(version_cls)
+
+        # Build primary key conditions
+        pk_conditions = [
+            getattr(version_cls, pk_name) == pk_value
+            for pk_name, pk_value in primary_key_values.items()
+        ]
+
+        # Find the version with highest transaction_id <= target
+        return (
+            session.query(version_cls)
+            .filter(
+                sa.and_(
+                    getattr(version_cls, tx_col) <= transaction_id,
+                    *pk_conditions
+                )
+            )
+            .order_by(getattr(version_cls, tx_col).desc())
+            .first()
+        )
+
 
 class ValidityFetcher(VersionObjectFetcher):
     def next_query(self, obj):
@@ -173,4 +305,44 @@ class ValidityFetcher(VersionObjectFetcher):
                 == getattr(obj, tx_column_name(obj)),
                 *parent_criteria(obj),
             )
+        )
+
+    def version_at(self, session, version_cls, primary_key_values: dict, transaction_id: int):
+        """
+        Returns the version that was active at the given transaction_id.
+
+        For validity strategy, uses the efficient range query:
+        - transaction_id <= target_transaction_id
+        - end_transaction_id > target_transaction_id OR end_transaction_id IS NULL
+
+        :param session: SQLAlchemy session
+        :param version_cls: The version class to query
+        :param primary_key_values: Dict mapping primary key column names to values
+        :param transaction_id: The transaction ID to query at
+        :returns: The version object active at that transaction, or None
+        """
+        tx_col = tx_column_name(version_cls)
+        end_tx_col = end_tx_column_name(version_cls)
+
+        # Build primary key conditions
+        pk_conditions = [
+            getattr(version_cls, pk_name) == pk_value
+            for pk_name, pk_value in primary_key_values.items()
+        ]
+
+        # Find version where transaction_id <= target AND
+        # (end_transaction_id > target OR end_transaction_id IS NULL)
+        return (
+            session.query(version_cls)
+            .filter(
+                sa.and_(
+                    getattr(version_cls, tx_col) <= transaction_id,
+                    sa.or_(
+                        getattr(version_cls, end_tx_col) > transaction_id,
+                        getattr(version_cls, end_tx_col).is_(None)
+                    ),
+                    *pk_conditions
+                )
+            )
+            .first()
         )

--- a/sqlalchemy_continuum/fetcher.py
+++ b/sqlalchemy_continuum/fetcher.py
@@ -55,7 +55,9 @@ class VersionObjectFetcher:
         """
         return self.next_query(obj).first()
 
-    def version_at(self, session, version_cls, primary_key_values: dict, transaction_id: int):
+    def version_at(
+        self, session, version_cls, primary_key_values: dict, transaction_id: int
+    ):
         """
         Returns the version that was active at the given transaction_id.
 
@@ -72,7 +74,7 @@ class VersionObjectFetcher:
         :param transaction_id: The transaction ID to query at
         :returns: The version object active at that transaction, or None
         """
-        raise NotImplementedError("Subclasses must implement version_at")
+        raise NotImplementedError('Subclasses must implement version_at')
 
     def all_versions(
         self,
@@ -140,7 +142,9 @@ class VersionObjectFetcher:
             if desc:
                 # In descending order: next is at lower index, previous is at higher index
                 version._next_cache = versions[i - 1] if i > 0 else None
-                version._previous_cache = versions[i + 1] if i < len(versions) - 1 else None
+                version._previous_cache = (
+                    versions[i + 1] if i < len(versions) - 1 else None
+                )
             else:
                 # In ascending order: previous is at lower index, next is at higher index
                 version._previous_cache = versions[i - 1] if i > 0 else None
@@ -241,7 +245,9 @@ class SubqueryFetcher(VersionObjectFetcher):
         """
         return self._next_prev_query(obj, 'next')
 
-    def version_at(self, session, version_cls, primary_key_values: dict, transaction_id: int):
+    def version_at(
+        self, session, version_cls, primary_key_values: dict, transaction_id: int
+    ):
         """
         Returns the version that was active at the given transaction_id.
 
@@ -266,10 +272,7 @@ class SubqueryFetcher(VersionObjectFetcher):
         return (
             session.query(version_cls)
             .filter(
-                sa.and_(
-                    getattr(version_cls, tx_col) <= transaction_id,
-                    *pk_conditions
-                )
+                sa.and_(getattr(version_cls, tx_col) <= transaction_id, *pk_conditions)
             )
             .order_by(getattr(version_cls, tx_col).desc())
             .first()
@@ -307,7 +310,9 @@ class ValidityFetcher(VersionObjectFetcher):
             )
         )
 
-    def version_at(self, session, version_cls, primary_key_values: dict, transaction_id: int):
+    def version_at(
+        self, session, version_cls, primary_key_values: dict, transaction_id: int
+    ):
         """
         Returns the version that was active at the given transaction_id.
 
@@ -339,9 +344,9 @@ class ValidityFetcher(VersionObjectFetcher):
                     getattr(version_cls, tx_col) <= transaction_id,
                     sa.or_(
                         getattr(version_cls, end_tx_col) > transaction_id,
-                        getattr(version_cls, end_tx_col).is_(None)
+                        getattr(version_cls, end_tx_col).is_(None),
                     ),
-                    *pk_conditions
+                    *pk_conditions,
                 )
             )
             .first()

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -88,6 +88,7 @@ class VersioningManager:
             'operation_type_column_name': 'operation_type',
             'strategy': 'validity',
             'use_module_name': False,
+            'create_composite_index': True,
         }
         if plugins is None:
             self.plugins = []

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -142,14 +142,19 @@ class TableBuilder:
         indexes = []
         tx_column_name = self.option('transaction_column_name')
 
-        # Get non-transaction primary key columns from parent table
-        parent_pk_columns = [col.name for col in self.parent_table.primary_key.columns]
+        # Get primary key columns from the version table itself, excluding
+        # the transaction_id column. We use the version table's columns
+        # directly because column aliases may cause the column key to differ
+        # from the parent table's column name (e.g., id vs _id).
+        entity_pk_columns = [
+            col for col in table.primary_key.columns if col.name != tx_column_name
+        ]
 
-        if not parent_pk_columns:
+        if not entity_pk_columns:
             return []
 
         # Build index columns: (pk1, pk2, ..., transaction_id DESC)
-        index_columns = [table.c[pk_name] for pk_name in parent_pk_columns]
+        index_columns = list(entity_pk_columns)
         index_columns.append(table.c[tx_column_name].desc())
 
         # Create a unique index name based on table name
@@ -160,7 +165,7 @@ class TableBuilder:
         # For validity strategy, also create index for end_transaction_id queries
         if self.option('strategy') == 'validity':
             end_tx_column_name = self.option('end_transaction_column_name')
-            validity_index_columns = [table.c[pk_name] for pk_name in parent_pk_columns]
+            validity_index_columns = list(entity_pk_columns)
             validity_index_columns.append(table.c[tx_column_name])
             validity_index_columns.append(table.c[end_tx_column_name])
 

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -123,16 +123,76 @@ class TableBuilder:
     def columns(self):
         return list(ColumnReflector(self.manager, self.parent_table, self.model))
 
+    def _build_composite_indexes(self, table):
+        """
+        Build composite indexes for efficient version queries.
+
+        Creates indexes on (primary_key_columns, transaction_id DESC) which
+        significantly speeds up common query patterns like:
+        - Finding a specific version of an entity
+        - Iterating through version history
+        - Point-in-time queries
+
+        The index is only created if create_composite_index option is True
+        (default: True).
+        """
+        if not self.option('create_composite_index'):
+            return []
+
+        indexes = []
+        tx_column_name = self.option('transaction_column_name')
+
+        # Get non-transaction primary key columns from parent table
+        parent_pk_columns = [
+            col.name for col in self.parent_table.primary_key.columns
+        ]
+
+        if not parent_pk_columns:
+            return []
+
+        # Build index columns: (pk1, pk2, ..., transaction_id DESC)
+        index_columns = [table.c[pk_name] for pk_name in parent_pk_columns]
+        index_columns.append(table.c[tx_column_name].desc())
+
+        # Create a unique index name based on table name
+        index_name = f'ix_{table.name}_pk_transaction_id'
+
+        indexes.append(
+            sa.Index(index_name, *index_columns)
+        )
+
+        # For validity strategy, also create index for end_transaction_id queries
+        if self.option('strategy') == 'validity':
+            end_tx_column_name = self.option('end_transaction_column_name')
+            validity_index_columns = [table.c[pk_name] for pk_name in parent_pk_columns]
+            validity_index_columns.append(table.c[tx_column_name])
+            validity_index_columns.append(table.c[end_tx_column_name])
+
+            validity_index_name = f'ix_{table.name}_pk_validity'
+            indexes.append(
+                sa.Index(validity_index_name, *validity_index_columns)
+            )
+
+        return indexes
+
     def __call__(self, extends=None):
         """
         Builds version table.
         """
         columns = self.columns if extends is None else []
         self.manager.plugins.after_build_version_table_columns(self, columns)
-        return sa.schema.Table(
+        table = sa.schema.Table(
             extends.name if extends is not None else self.table_name,
             self.parent_table.metadata,
             *columns,
             schema=self.parent_table.schema,
             extend_existing=extends is not None,
         )
+
+        # Add composite indexes for efficient version queries
+        if extends is None:
+            for index in self._build_composite_indexes(table):
+                # Indexes are automatically associated with the table when created
+                pass
+
+        return table

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -143,9 +143,7 @@ class TableBuilder:
         tx_column_name = self.option('transaction_column_name')
 
         # Get non-transaction primary key columns from parent table
-        parent_pk_columns = [
-            col.name for col in self.parent_table.primary_key.columns
-        ]
+        parent_pk_columns = [col.name for col in self.parent_table.primary_key.columns]
 
         if not parent_pk_columns:
             return []
@@ -157,9 +155,7 @@ class TableBuilder:
         # Create a unique index name based on table name
         index_name = f'ix_{table.name}_pk_transaction_id'
 
-        indexes.append(
-            sa.Index(index_name, *index_columns)
-        )
+        indexes.append(sa.Index(index_name, *index_columns))
 
         # For validity strategy, also create index for end_transaction_id queries
         if self.option('strategy') == 'validity':
@@ -169,9 +165,7 @@ class TableBuilder:
             validity_index_columns.append(table.c[end_tx_column_name])
 
             validity_index_name = f'ix_{table.name}_pk_validity'
-            indexes.append(
-                sa.Index(validity_index_name, *validity_index_columns)
-            )
+            indexes.append(sa.Index(validity_index_name, *validity_index_columns))
 
         return indexes
 

--- a/sqlalchemy_continuum/version.py
+++ b/sqlalchemy_continuum/version.py
@@ -64,7 +64,9 @@ class VersionClassBase:
         )
 
     @classmethod
-    def version_at(cls, session, primary_key_values: Dict, transaction_id: int) -> Optional['VersionClassBase']:
+    def version_at(
+        cls, session, primary_key_values: Dict, transaction_id: int
+    ) -> Optional['VersionClassBase']:
         """
         Efficiently retrieve the version that was active at a specific transaction.
 

--- a/sqlalchemy_continuum/version.py
+++ b/sqlalchemy_continuum/version.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Optional
+
 import sqlalchemy as sa
 
 from .reverter import Reverter
@@ -5,13 +7,25 @@ from .utils import get_versioning_manager, is_internal_column, parent_class
 
 
 class VersionClassBase:
+    # Cache attributes for pre-loaded previous/next versions
+    _previous_cache: Optional['VersionClassBase'] = None
+    _next_cache: Optional['VersionClassBase'] = None
+    _cache_populated: bool = False
+
     @property
     def previous(self):
         """
         Returns the previous version relative to this version in the version
         history. If current version is the first version this method returns
         None.
+
+        If versions have been pre-fetched using `all_versions()` with
+        `link_versions()`, this will use the cached value instead of
+        making a database query.
         """
+        # Check if cache was explicitly populated (even if previous is None)
+        if hasattr(self, '_previous_cache') and self._cache_populated:
+            return self._previous_cache
         return (
             get_versioning_manager(self)
             .fetcher(parent_class(self.__class__))
@@ -24,7 +38,14 @@ class VersionClassBase:
         Returns the next version relative to this version in the version
         history. If current version is the last version this method returns
         None.
+
+        If versions have been pre-fetched using `all_versions()` with
+        `link_versions()`, this will use the cached value instead of
+        making a database query.
         """
+        # Check if cache was explicitly populated (even if next is None)
+        if hasattr(self, '_next_cache') and self._cache_populated:
+            return self._next_cache
         return (
             get_versioning_manager(self)
             .fetcher(parent_class(self.__class__))
@@ -41,6 +62,86 @@ class VersionClassBase:
             .fetcher(parent_class(self.__class__))
             .index(self)
         )
+
+    @classmethod
+    def version_at(cls, session, primary_key_values: Dict, transaction_id: int) -> Optional['VersionClassBase']:
+        """
+        Efficiently retrieve the version that was active at a specific transaction.
+
+        This is more efficient than iterating through versions manually, especially
+        when using the validity strategy which can use range conditions.
+
+        Example::
+
+            # Get the version of Article #5 that was active at transaction #100
+            version = ArticleVersion.version_at(
+                session,
+                {'id': 5},
+                transaction_id=100
+            )
+
+        :param session: SQLAlchemy session
+        :param primary_key_values: Dict mapping primary key column names to values
+        :param transaction_id: The transaction ID to query at
+        :returns: The version object active at that transaction, or None
+        """
+        manager = get_versioning_manager(cls)
+        parent_cls = parent_class(cls)
+        fetcher = manager.fetcher(parent_cls)
+        return fetcher.version_at(session, cls, primary_key_values, transaction_id)
+
+    @classmethod
+    def all_versions(
+        cls,
+        session,
+        primary_key_values: Dict,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        desc: bool = True,
+        link: bool = True,
+    ) -> List['VersionClassBase']:
+        """
+        Efficiently fetch all versions for an entity in a single query.
+
+        This avoids N+1 queries when iterating through version history
+        by fetching all versions at once. When `link=True`, the returned
+        versions will have their `.previous` and `.next` properties
+        pre-populated from the cache.
+
+        Example::
+
+            # Get all versions of Article #5, newest first
+            versions = ArticleVersion.all_versions(
+                session,
+                {'id': 5},
+                limit=10  # Only get the 10 most recent versions
+            )
+
+            # Iterate without N+1 queries
+            for version in versions:
+                print(version.changeset)
+                print(version.previous)  # Uses cached value, no query
+
+        :param session: SQLAlchemy session
+        :param primary_key_values: Dict mapping primary key column names to values
+        :param limit: Maximum number of versions to return (None for all)
+        :param offset: Number of versions to skip
+        :param desc: If True, return newest versions first (default)
+        :param link: If True, pre-populate previous/next caches (default)
+        :returns: List of version objects
+        """
+        manager = get_versioning_manager(cls)
+        parent_cls = parent_class(cls)
+        fetcher = manager.fetcher(parent_cls)
+
+        versions = fetcher.all_versions(
+            session, cls, primary_key_values, limit=limit, offset=offset, desc=desc
+        )
+
+        if link and versions:
+            fetcher.link_versions(versions, desc=desc)
+
+        return versions
 
     @property
     def changeset(self):

--- a/tests/test_efficient_queries.py
+++ b/tests/test_efficient_queries.py
@@ -1,0 +1,216 @@
+"""Tests for efficient version query features."""
+
+from tests import TestCase, create_test_cases, setting_variants
+
+
+class EfficientQueriesTestCase(TestCase):
+    """Test efficient version query methods."""
+
+    def _create_article_with_versions(self, num_versions=4):
+        """Helper to create an article with multiple versions."""
+        names = [f'Version {i}' for i in range(num_versions)]
+
+        article = self.Article(name=names[0])
+        self.session.add(article)
+        self.session.commit()
+
+        for name in names[1:]:
+            article.name = name
+            self.session.commit()
+
+        return article, names
+
+    def _get_tx_id(self, version_obj):
+        """Get the transaction ID from a version object, handling custom column names."""
+        return getattr(version_obj, self.transaction_column_name)
+
+    def test_version_at_returns_correct_version(self):
+        """Test that version_at returns the version active at a given transaction."""
+        article, names = self._create_article_with_versions(4)
+
+        # Get all versions to find their transaction IDs
+        versions = list(article.versions)
+
+        # Query for version at the second transaction
+        target_tx = self._get_tx_id(versions[1])
+        result = self.ArticleVersion.version_at(
+            self.session,
+            {'id': article.id},
+            transaction_id=target_tx
+        )
+
+        assert result is not None
+        assert result.name == names[1]
+        assert self._get_tx_id(result) == target_tx
+
+    def test_version_at_returns_none_for_nonexistent(self):
+        """Test that version_at returns None when no version exists."""
+        article, _ = self._create_article_with_versions(2)
+
+        # Query for a transaction ID that doesn't exist (before first version)
+        result = self.ArticleVersion.version_at(
+            self.session,
+            {'id': article.id},
+            transaction_id=0
+        )
+
+        assert result is None
+
+    def test_version_at_with_wrong_primary_key(self):
+        """Test that version_at returns None for non-existent entity."""
+        article, _ = self._create_article_with_versions(2)
+
+        versions = list(article.versions)
+        target_tx = self._get_tx_id(versions[0])
+
+        result = self.ArticleVersion.version_at(
+            self.session,
+            {'id': 99999},  # Non-existent ID
+            transaction_id=target_tx
+        )
+
+        assert result is None
+
+    def test_all_versions_returns_all(self):
+        """Test that all_versions returns all versions of an entity."""
+        article, names = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id}
+        )
+
+        assert len(versions) == 4
+        # Default is desc=True, so newest first
+        assert versions[0].name == names[3]
+        assert versions[3].name == names[0]
+
+    def test_all_versions_with_limit(self):
+        """Test that all_versions respects limit parameter."""
+        article, names = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id},
+            limit=2
+        )
+
+        assert len(versions) == 2
+        # Should get the 2 most recent (desc=True by default)
+        assert versions[0].name == names[3]
+        assert versions[1].name == names[2]
+
+    def test_all_versions_with_offset(self):
+        """Test that all_versions respects offset parameter."""
+        article, names = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id},
+            offset=1,
+            limit=2
+        )
+
+        assert len(versions) == 2
+        # Skip first (newest), get next 2
+        assert versions[0].name == names[2]
+        assert versions[1].name == names[1]
+
+    def test_all_versions_ascending_order(self):
+        """Test that all_versions can return in ascending order."""
+        article, names = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id},
+            desc=False
+        )
+
+        assert len(versions) == 4
+        # Oldest first
+        assert versions[0].name == names[0]
+        assert versions[3].name == names[3]
+
+    def test_all_versions_links_previous_next(self):
+        """Test that all_versions with link=True pre-populates caches."""
+        article, names = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id},
+            link=True  # Default
+        )
+
+        # Check that caches are populated
+        assert versions[0]._cache_populated is True
+        assert versions[0].next is None  # Newest has no next
+        assert versions[0].previous == versions[1]
+
+        assert versions[1].next == versions[0]
+        assert versions[1].previous == versions[2]
+
+        assert versions[3].previous is None  # Oldest has no previous
+        assert versions[3].next == versions[2]
+
+    def test_all_versions_no_link(self):
+        """Test that all_versions with link=False doesn't populate caches."""
+        article, _ = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id},
+            link=False
+        )
+
+        # Caches should not be populated
+        assert not hasattr(versions[0], '_cache_populated') or not versions[0]._cache_populated
+
+    def test_all_versions_ascending_links_correctly(self):
+        """Test that link_versions works correctly with ascending order."""
+        article, names = self._create_article_with_versions(4)
+
+        versions = self.ArticleVersion.all_versions(
+            self.session,
+            {'id': article.id},
+            desc=False,  # Ascending - oldest first
+            link=True
+        )
+
+        # In ascending order: versions[0] is oldest, versions[-1] is newest
+        assert versions[0].previous is None  # Oldest has no previous
+        assert versions[0].next == versions[1]
+
+        assert versions[3].next is None  # Newest has no next
+        assert versions[3].previous == versions[2]
+
+
+class CompositeIndexTestCase(TestCase):
+    """Test that composite indexes are created correctly."""
+
+    def test_composite_index_exists_by_default(self):
+        """Test that composite index is created by default."""
+        # Get the version table
+        version_table = self.ArticleVersion.__table__
+
+        # Check for index with pattern ix_<table>_pk_transaction_id
+        index_names = [idx.name for idx in version_table.indexes]
+
+        expected_index = f'ix_{version_table.name}_pk_transaction_id'
+        assert expected_index in index_names, f"Expected index {expected_index} not found in {index_names}"
+
+    def test_validity_strategy_creates_validity_index(self):
+        """Test that validity strategy creates additional validity index."""
+        if self.versioning_strategy != 'validity':
+            return  # Skip for subquery strategy
+
+        version_table = self.ArticleVersion.__table__
+
+        index_names = [idx.name for idx in version_table.indexes]
+
+        expected_index = f'ix_{version_table.name}_pk_validity'
+        assert expected_index in index_names, f"Expected index {expected_index} not found in {index_names}"
+
+
+# Create test cases for all strategy variants
+create_test_cases(EfficientQueriesTestCase, setting_variants)
+create_test_cases(CompositeIndexTestCase, setting_variants)

--- a/tests/test_efficient_queries.py
+++ b/tests/test_efficient_queries.py
@@ -34,9 +34,7 @@ class EfficientQueriesTestCase(TestCase):
         # Query for version at the second transaction
         target_tx = self._get_tx_id(versions[1])
         result = self.ArticleVersion.version_at(
-            self.session,
-            {'id': article.id},
-            transaction_id=target_tx
+            self.session, {'id': article.id}, transaction_id=target_tx
         )
 
         assert result is not None
@@ -49,9 +47,7 @@ class EfficientQueriesTestCase(TestCase):
 
         # Query for a transaction ID that doesn't exist (before first version)
         result = self.ArticleVersion.version_at(
-            self.session,
-            {'id': article.id},
-            transaction_id=0
+            self.session, {'id': article.id}, transaction_id=0
         )
 
         assert result is None
@@ -66,7 +62,7 @@ class EfficientQueriesTestCase(TestCase):
         result = self.ArticleVersion.version_at(
             self.session,
             {'id': 99999},  # Non-existent ID
-            transaction_id=target_tx
+            transaction_id=target_tx,
         )
 
         assert result is None
@@ -75,10 +71,7 @@ class EfficientQueriesTestCase(TestCase):
         """Test that all_versions returns all versions of an entity."""
         article, names = self._create_article_with_versions(4)
 
-        versions = self.ArticleVersion.all_versions(
-            self.session,
-            {'id': article.id}
-        )
+        versions = self.ArticleVersion.all_versions(self.session, {'id': article.id})
 
         assert len(versions) == 4
         # Default is desc=True, so newest first
@@ -90,9 +83,7 @@ class EfficientQueriesTestCase(TestCase):
         article, names = self._create_article_with_versions(4)
 
         versions = self.ArticleVersion.all_versions(
-            self.session,
-            {'id': article.id},
-            limit=2
+            self.session, {'id': article.id}, limit=2
         )
 
         assert len(versions) == 2
@@ -105,10 +96,7 @@ class EfficientQueriesTestCase(TestCase):
         article, names = self._create_article_with_versions(4)
 
         versions = self.ArticleVersion.all_versions(
-            self.session,
-            {'id': article.id},
-            offset=1,
-            limit=2
+            self.session, {'id': article.id}, offset=1, limit=2
         )
 
         assert len(versions) == 2
@@ -121,9 +109,7 @@ class EfficientQueriesTestCase(TestCase):
         article, names = self._create_article_with_versions(4)
 
         versions = self.ArticleVersion.all_versions(
-            self.session,
-            {'id': article.id},
-            desc=False
+            self.session, {'id': article.id}, desc=False
         )
 
         assert len(versions) == 4
@@ -138,7 +124,7 @@ class EfficientQueriesTestCase(TestCase):
         versions = self.ArticleVersion.all_versions(
             self.session,
             {'id': article.id},
-            link=True  # Default
+            link=True,  # Default
         )
 
         # Check that caches are populated
@@ -157,13 +143,14 @@ class EfficientQueriesTestCase(TestCase):
         article, _ = self._create_article_with_versions(4)
 
         versions = self.ArticleVersion.all_versions(
-            self.session,
-            {'id': article.id},
-            link=False
+            self.session, {'id': article.id}, link=False
         )
 
         # Caches should not be populated
-        assert not hasattr(versions[0], '_cache_populated') or not versions[0]._cache_populated
+        assert (
+            not hasattr(versions[0], '_cache_populated')
+            or not versions[0]._cache_populated
+        )
 
     def test_all_versions_ascending_links_correctly(self):
         """Test that link_versions works correctly with ascending order."""
@@ -173,7 +160,7 @@ class EfficientQueriesTestCase(TestCase):
             self.session,
             {'id': article.id},
             desc=False,  # Ascending - oldest first
-            link=True
+            link=True,
         )
 
         # In ascending order: versions[0] is oldest, versions[-1] is newest
@@ -196,7 +183,9 @@ class CompositeIndexTestCase(TestCase):
         index_names = [idx.name for idx in version_table.indexes]
 
         expected_index = f'ix_{version_table.name}_pk_transaction_id'
-        assert expected_index in index_names, f"Expected index {expected_index} not found in {index_names}"
+        assert expected_index in index_names, (
+            f'Expected index {expected_index} not found in {index_names}'
+        )
 
     def test_validity_strategy_creates_validity_index(self):
         """Test that validity strategy creates additional validity index."""
@@ -208,7 +197,9 @@ class CompositeIndexTestCase(TestCase):
         index_names = [idx.name for idx in version_table.indexes]
 
         expected_index = f'ix_{version_table.name}_pk_validity'
-        assert expected_index in index_names, f"Expected index {expected_index} not found in {index_names}"
+        assert expected_index in index_names, (
+            f'Expected index {expected_index} not found in {index_names}'
+        )
 
 
 # Create test cases for all strategy variants


### PR DESCRIPTION
This commit adds several features to optimize version queries:

1. version_at() class method on version objects - efficiently retrieve the version that was active at a specific transaction using an optimized query pattern for both validity and subquery strategies

2. all_versions() class method with link option - batch fetch all versions for an entity in a single query, optionally pre-populating the previous/next navigation caches to avoid N+1 queries

3. Automatic composite indexes on version tables - creates (pk_columns, transaction_id DESC) index for efficient version lookups and (pk_columns, transaction_id, end_transaction_id) for validity strategy temporal queries. Controlled by create_composite_index option.

4. Updated documentation with index recommendations and efficient query patterns