### PR TITLE
Handle Composite columns in builder

### DIFF
--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -3,6 +3,7 @@ from functools import wraps
 from inspect import getmro
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Composite
 from sqlalchemy.orm.descriptor_props import ConcreteInheritedProperty
 from ._compat import get_declarative_base
 
@@ -194,6 +195,9 @@ class Builder:
             for prop in sa.inspect(cls).iterate_properties:
                 if isinstance(prop, ConcreteInheritedProperty):
                     # ConcreteInheritedProperty doesn't have a dispatch, so we can't set active_history
+                    continue
+                if isinstance(prop, Composite):
+                    # Composite doesn't have a dispatch, so we can't set active_history
                     continue
 
                 impl = getattr(cls, prop.key).impl


### PR DESCRIPTION
Here is an example which raises an error.

```python
import dataclasses

from sqlalchemy.orm import DeclarativeBase, Mapped, composite, mapped_column

@dataclasses.dataclass
class Point:
    x: int
    y: int

    def __composite_values__(self):
        return self.x, self.y

class Demo(DeclarativeBase):
    p: Mapped[Point] = composite(
        Point,
        mapped_column("px", Integer),
        mapped_column("py", Integer),
    )
```

The error:

```
File ".venv/lib/python3.14/site-packages/sqlalchemy_continuum/builder.py", line 200, in enable_active_history
    impl.active_history = True
    ^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.14/site-packages/sqlalchemy/orm/attributes.py", line 952, in _set_active_history
    self.dispatch._active_history = value
    ^^^^^^^^^^^^^
AttributeError: 'sqlalchemy.orm.descriptor_props.DescriptorProperty.instrument_class.<locals>._ProxyImpl' object has no attribute 'dispatch'
```

With the patch proposed everything seems to work fine.