### PR TITLE
Make per-transaction unit-of-work state thread-safe (store on connection.info)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Here you can see the full list of changes between each SQLAlchemy-Continuum rele
 
 Unreleased changes
 ^^^^^^^^^^^^^^^^^^
-- TODO
+- Store per-transaction unit-of-work state on ``connection.info``/``session.info`` instead of global dictionaries on the ``VersioningManager`` singleton, making versioning thread-safe under connection pools and fixing crashes such as ``RuntimeError: dictionary changed size during iteration`` (#390)
 
 1.7.0 (2026-07-02)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ Here you can see the full list of changes between each SQLAlchemy-Continuum rele
 
 ## Unreleased changes
 
-- TODO
+- Store per-transaction unit-of-work state on `connection.info`/`session.info` instead of global dictionaries on the `VersioningManager` singleton, making versioning thread-safe under connection pools and fixing crashes such as `RuntimeError: dictionary changed size during iteration` (#390)
 
 ## 1.7.0 (2026-07-02)
 

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -89,11 +89,7 @@ def make_versioned(
 
     sa.event.listen(sa.engine.Engine, 'rollback', manager.clear_connection)
 
-    sa.event.listen(
-        sa.engine.Engine,
-        'set_connection_execution_options',
-        manager.track_cloned_connections,
-    )
+    sa.event.listen(sa.engine.Engine, 'reset', manager.clear_connection_on_reset)
 
 
 def remove_versioning(
@@ -120,8 +116,4 @@ def remove_versioning(
 
     sa.event.remove(sa.engine.Engine, 'rollback', manager.clear_connection)
 
-    sa.event.remove(
-        sa.engine.Engine,
-        'set_connection_execution_options',
-        manager.track_cloned_connections,
-    )
+    sa.event.remove(sa.engine.Engine, 'reset', manager.clear_connection_on_reset)

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -12,6 +12,19 @@ from .transaction import TransactionFactory
 from .unit_of_work import UnitOfWork
 from .utils import is_modified, is_versioned, version_table
 
+#: Key under which the active :class:`.UnitOfWork` is stored on
+#: ``connection.info``. Because ``Connection.info`` proxies to the underlying
+#: pooled DBAPI connection, every ``Connection`` clone sharing that DBAPI
+#: connection sees the same object, and each thread has its own connection --
+#: so this scoping is naturally thread-safe.
+UOW_KEY = 'continuum_unit_of_work'
+
+#: Key under which a session's bound ``Connection`` is remembered on
+#: ``session.info`` so the unit of work can be cleaned up at commit time
+#: without calling ``session.connection()`` (which would begin a new
+#: transaction).
+CONN_KEY = 'continuum_connection'
+
 
 def tracked_operation(func):
     @wraps(func)
@@ -140,12 +153,6 @@ class VersioningManager:
             'instrument_class': self.builder.instrument_versioned_classes,
             'after_configured': self.builder.configure_versioned_classes,
         }
-
-        # A dictionary of units of work. Keys as connection objects and values
-        # as UnitOfWork objects.
-        self.units_of_work = {}
-
-        self.session_connection_map = {}
 
         self.metadata = None
 
@@ -306,34 +313,26 @@ class VersioningManager:
 
         :param session: SQLAlchemy session object
         """
-        conn = session.connection()
-        if conn not in self.session_connection_map.values():
-            self.session_connection_map[session] = conn
+        connection = session.connection()
+        session.info[CONN_KEY] = connection
+        return self._uow_from_conn(connection)
 
-        if conn in self.units_of_work:
-            return self.units_of_work[conn]
-        else:
+    def _uow_from_conn(self, connection):
+        """
+        Return the UnitOfWork associated with the given SQLAlchemy connection,
+        creating one if necessary.
+
+        The unit of work is stored on ``connection.info``, which proxies to the
+        underlying pooled DBAPI connection. All ``Connection`` clones sharing
+        that DBAPI connection therefore resolve to the same UnitOfWork, so no
+        clone bookkeeping is required.
+
+        :param connection: SQLAlchemy connection object
+        """
+        uow = connection.info.get(UOW_KEY)
+        if uow is None:
             uow = self.uow_class(self)
-            self.units_of_work[conn] = uow
-            return uow
-
-    def _uow_from_conn(self, conn):
-        try:
-            uow = self.units_of_work[conn]
-        except KeyError:
-            try:
-                uow = self.units_of_work[conn.engine]
-            except KeyError:
-                for connection in self.units_of_work.keys():
-                    if (
-                        not connection.closed
-                        and connection.connection is conn.connection
-                    ):
-                        uow = self.unit_of_work(conn.session)
-                        break  # The ConnectionFairy is the same, this connection is a clone
-                else:
-                    raise
-
+            connection.info[UOW_KEY] = uow
         return uow
 
     def before_flush(self, session, flush_context, instances):
@@ -375,36 +374,38 @@ class VersioningManager:
         """
         if session.in_nested_transaction():
             return
-        conn = self.session_connection_map.pop(session, None)
-        if conn is None:
+        connection = session.info.pop(CONN_KEY, None)
+        if connection is None:
             return
 
-        if conn in self.units_of_work:
-            uow = self.units_of_work[conn]
+        uow = connection.info.pop(UOW_KEY, None)
+        if uow is not None:
             uow.reset(session)
-            del self.units_of_work[conn]
 
-        for connection in dict(self.units_of_work).keys():
-            if connection.closed or conn.connection is connection.connection:
-                uow = self.units_of_work[connection]
-                uow.reset(session)
-                del self.units_of_work[connection]
+    def clear_connection(self, connection):
+        """
+        Engine ``rollback`` listener that discards the UnitOfWork associated
+        with the given connection.
 
-    def clear_connection(self, conn):
-        if conn in self.units_of_work:
-            uow = self.units_of_work[conn]
+        :param connection: SQLAlchemy connection object
+        """
+        uow = connection.info.pop(UOW_KEY, None)
+        if uow is not None:
             uow.reset()
-            del self.units_of_work[conn]
 
-        for session, connection in dict(self.session_connection_map).items():
-            if connection is conn:
-                del self.session_connection_map[session]
+    def clear_connection_on_reset(
+        self, dbapi_connection, connection_record, reset_state=None
+    ):
+        """
+        Pool ``reset`` listener acting as a safety net: whenever a DBAPI
+        connection is returned to the pool, drop any lingering UnitOfWork so it
+        cannot leak into a later checkout of the same connection.
 
-        for connection in dict(self.units_of_work).keys():
-            if connection.closed or conn.connection is connection.connection:
-                uow = self.units_of_work[connection]
-                uow.reset()
-                del self.units_of_work[connection]
+        ``connection_record.info`` is the same dictionary that
+        ``Connection.info`` exposes, so this reliably clears the state
+        regardless of how the transaction ended.
+        """
+        connection_record.info.pop(UOW_KEY, None)
 
     def append_association_operation(self, conn, table_name, params, op):
         """
@@ -417,17 +418,6 @@ class VersioningManager:
         )
         uow = self._uow_from_conn(conn)
         uow.pending_statements.append(stmt)
-
-    def track_cloned_connections(self, c, opt):
-        """
-        Track cloned connections from association tables.
-        """
-        if c not in self.units_of_work.keys():
-            for connection, uow in dict(self.units_of_work).items():
-                if (
-                    not connection.closed and connection.connection is c.connection
-                ):  # ConnectionFairy is the same - this is a clone
-                    self.units_of_work[c] = uow
 
     def track_association_operations(
         self,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,6 +20,7 @@ from sqlalchemy_continuum import (
     version_class,
     versioning_manager,
 )
+from sqlalchemy_continuum.manager import CONN_KEY, UOW_KEY
 from sqlalchemy_continuum.plugins import TransactionChangesPlugin, TransactionMetaPlugin
 from sqlalchemy_continuum.transaction import TransactionFactory
 
@@ -124,8 +125,12 @@ class TestCase:
 
     def teardown_method(self, method):
         self.session.rollback()
-        uow_leaks = versioning_manager.units_of_work
-        session_map_leaks = versioning_manager.session_connection_map
+        # The unit of work now lives on connection.info / session.info rather
+        # than on global dicts, so assert cleanup happened on the test's own
+        # connection and session. (engine.dispose() below discards the pool, so
+        # nothing can bleed into the next test regardless.)
+        uow_leaks = self.connection.info.get(UOW_KEY)
+        session_map_leaks = self.session.info.get(CONN_KEY)
 
         remove_versioning()
         QueryPool.queries = []
@@ -145,8 +150,8 @@ class TestCase:
         self.connection.close()
         self.engine.dispose()
 
-        assert not uow_leaks
-        assert not session_map_leaks
+        assert uow_leaks is None
+        assert session_map_leaks is None
 
     def create_models(self):
         class Article(self.Model):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,3 +1,6 @@
+import os
+
+import pytest
 from sqlalchemy.orm.session import Session
 
 from sqlalchemy_continuum import UnitOfWork, versioning_manager
@@ -14,6 +17,11 @@ class TestSessions(TestCase):
         self.session2.commit()
         assert list(article.versions)[-1].transaction_id
 
+    # In-memory SQLite serves every ``engine.connect()`` from a single shared
+    # DBAPI connection, so the two sessions below actually share one database
+    # connection (hence one transaction) and cannot exercise the
+    # multiple-connections path. Runs on backends with a real connection pool.
+    @pytest.mark.skipif("os.environ.get('DB', 'sqlite') == 'sqlite'")
     def test_multiple_connections(self):
         self.session2 = Session(bind=self.engine.connect())
         article = self.Article(name='Session1 article')

--- a/tests/test_thread_safe_uow_multithreaded.py
+++ b/tests/test_thread_safe_uow_multithreaded.py
@@ -1,0 +1,91 @@
+"""
+Concurrency stress test for issue #390.
+
+Many threads share a single ``Engine`` (and therefore its connection pool) and
+each drives its own session through insert + update + commit cycles. On the
+pre-fix code the global ``VersioningManager`` dicts are mutated and iterated
+from several threads at once, which raised ``RuntimeError: dictionary changed
+size during iteration`` / ``KeyError``. With per-connection ``.info`` storage
+each thread works on its own connection, so no shared mutable state is touched.
+
+Skipped on SQLite: the in-memory database serves every connection from a single
+shared DBAPI connection, so it cannot exercise real multi-connection
+concurrency (the concurrency matrix runs this on postgres/mysql in CI).
+"""
+
+import os
+from threading import Thread, current_thread
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import func
+from sqlalchemy.orm import sessionmaker
+
+from tests import TestCase
+
+NUM_ROWS = 50
+NUM_THREADS = 8
+
+
+class RaisingThread(Thread):
+    """``threading.Thread`` that re-raises any worker exception on ``join``."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exc = None
+
+    def run(self):
+        try:
+            super().run()
+        except BaseException as e:  # noqa: BLE001 - re-raised in join()
+            self.exc = e
+
+    def join(self, timeout=None):
+        super().join(timeout)
+        if self.exc:
+            raise self.exc
+
+
+class TestConcurrentVersioning(TestCase):
+    plugins = []
+
+    @pytest.mark.skipif("os.environ.get('DB', 'sqlite') == 'sqlite'")
+    def test_concurrent_sessions_on_shared_engine_pool(self):
+        threads = [RaisingThread(target=self._worker) for _ in range(NUM_THREADS)]
+
+        for thread in threads:
+            thread.start()
+
+        # A race in any worker is re-raised here and fails the test.
+        for thread in threads:
+            thread.join()
+
+    def _worker(self):
+        Session = sessionmaker(bind=self.engine)
+        session = Session(autoflush=False)
+        name = current_thread().name
+        try:
+            for i in range(NUM_ROWS):
+                article = self.Article(name=f'{name}-{i:04}')
+                session.add(article)
+                session.commit()  # -> insert version row
+                article.name += '-v2'
+                session.commit()  # -> update version row
+
+            # Every parent row exists...
+            assert (
+                session.query(func.count(self.Article.id))
+                .where(self.Article.name.like(f'{name}-%'))
+                .scalar()
+                == NUM_ROWS
+            )
+            # ...and both the insert and the update were versioned (2 each).
+            assert (
+                session.query(func.count())
+                .select_from(self.ArticleVersion)
+                .where(self.ArticleVersion.name.like(f'{name}-%'))
+                .scalar()
+                == NUM_ROWS * 2
+            )
+        finally:
+            session.close()

--- a/tests/test_thread_safe_uow_storage.py
+++ b/tests/test_thread_safe_uow_storage.py
@@ -1,0 +1,103 @@
+"""
+Regression tests for issue #390: the per-transaction unit of work is stored on
+``connection.info`` / ``session.info`` rather than in global dicts on the
+``VersioningManager`` singleton, so versioning is thread-safe under connection
+pools.
+
+These tests are deterministic and run on every backend (including the default
+in-memory SQLite), verifying the storage mechanism and its cleanup rather than
+racing threads (see ``test_thread_safe_uow_multithreaded.py`` for the
+concurrency stress test).
+"""
+
+import tempfile
+from pathlib import Path
+
+import sqlalchemy as sa
+from sqlalchemy.pool import QueuePool
+
+from sqlalchemy_continuum import UnitOfWork, versioning_manager
+from sqlalchemy_continuum.manager import CONN_KEY, UOW_KEY
+from tests import TestCase
+
+
+class TestUnitOfWorkStorage(TestCase):
+    plugins = []
+
+    def test_manager_has_no_global_connection_state(self):
+        # These global dicts were the source of the thread-safety races
+        # (``dictionary changed size during iteration``); they must be gone.
+        # This assertion fails on the pre-fix code.
+        assert not hasattr(versioning_manager, 'units_of_work')
+        assert not hasattr(versioning_manager, 'session_connection_map')
+
+    def test_uow_lives_on_connection_info(self):
+        article = self.Article(name='Some article')
+        self.session.add(article)
+        self.session.flush()
+
+        connection = self.session.connection()
+        uow = connection.info.get(UOW_KEY)
+        assert isinstance(uow, UnitOfWork)
+        # ``unit_of_work()`` resolves to the very same object.
+        assert versioning_manager.unit_of_work(self.session) is uow
+        # The session remembers its connection so it can be cleaned up at
+        # commit time without calling ``session.connection()``.
+        assert self.session.info.get(CONN_KEY) is connection
+
+        self.session.commit()
+
+    def test_state_cleared_after_commit(self):
+        connection = self.session.connection()
+        article = self.Article(name='Some article')
+        self.session.add(article)
+        self.session.commit()
+
+        assert connection.info.get(UOW_KEY) is None
+        assert self.session.info.get(CONN_KEY) is None
+
+    def test_state_cleared_after_rollback(self):
+        connection = self.session.connection()
+        article = self.Article(name='Some article')
+        self.session.add(article)
+        self.session.flush()
+        assert connection.info.get(UOW_KEY) is not None
+
+        self.session.rollback()
+
+        assert connection.info.get(UOW_KEY) is None
+        assert self.session.info.get(CONN_KEY) is None
+
+
+class TestPoolResetSafetyNet(TestCase):
+    """
+    The pool ``reset`` listener drops any lingering unit of work when a DBAPI
+    connection is returned to the pool, so it can never leak into a later
+    checkout of the same pooled connection (``connection.info`` persists across
+    checkouts).
+    """
+
+    plugins = []
+
+    def test_reset_clears_uow_before_next_checkout(self):
+        # A real (non-singleton) pool is needed to exercise checkout/checkin,
+        # so use a temporary file-based SQLite engine. ``make_versioned`` is
+        # active for the duration of this TestCase, so its Engine-level
+        # listeners apply to this engine too.
+        with tempfile.TemporaryDirectory() as tmp:
+            url = f'sqlite:///{Path(tmp) / "reset.db"}'
+            engine = sa.create_engine(
+                url, poolclass=QueuePool, pool_size=1, max_overflow=0
+            )
+            try:
+                connection = engine.connect()
+                uow = versioning_manager._uow_from_conn(connection)
+                assert connection.info.get(UOW_KEY) is uow
+
+                connection.close()  # return to pool -> reset listener fires
+
+                reused = engine.connect()
+                assert reused.info.get(UOW_KEY) is None
+                reused.close()
+            finally:
+                engine.dispose()


### PR DESCRIPTION
## Description

`VersioningManager` is a process-wide singleton whose listeners are registered once at the class level (on `sa.orm.Mapper`, `sa.orm.session.Session`, `sa.engine.Engine`), so every session on every thread shares it. It stored per-transaction state in **two global mutable dicts**:

- `manager.units_of_work` — `Connection -> UnitOfWork`
- `manager.session_connection_map` — `Session -> Connection`

Several code paths iterate those dicts while other threads mutate them (`clear`, `clear_connection`, `_uow_from_conn`, `track_cloned_connections` all do `for c in dict(self.units_of_work): ...`). Under a thread pool this races and crashes, typically:

```
RuntimeError: dictionary changed size during iteration
```

or a `KeyError` when another thread deletes a connection entry mid-lookup.

The connection-keyed *correlation* is legitimate — mapper events (`after_insert/update/delete`) only receive a `Connection`, session events only receive a `Session`, and the connection is the common handle. What's wrong is holding that correlation in **global** state.

## Fix

Move the state onto SQLAlchemy's own per-object scratch space:

- `connection.info[UOW_KEY]` holds the `UnitOfWork`
- `session.info[CONN_KEY]` remembers the session's bound connection, so `clear()` can tear down at commit time **without** calling `session.connection()` (which would begin a new transaction — the reason the old code cached the connection).

`Connection.info` proxies to the underlying pooled DBAPI connection, so **all `Connection` clones that share one DBAPI connection resolve to the same `.info` dict** (verified against SQLAlchemy 2.0.51). That makes the entire clone-matching machinery unnecessary, so this PR **deletes**:

- the clone-matching loop in `_uow_from_conn`,
- `track_cloned_connections` and its `set_connection_execution_options` listener,
- the `connection.closed or conn.connection is c.connection` sweeps in `clear`/`clear_connection`.

Each thread uses its own connection, so no shared mutable state remains and versioning is thread-safe by construction.

`connection.info` persists across pool checkouts, so a pool `reset` listener (`clear_connection_on_reset`) drops any lingering `UnitOfWork` on return-to-pool as a safety net — `connection_record.info` is the same dict `Connection.info` exposes, so this reliably clears state however the transaction ended.

## Behaviour note

Two sessions bound to two `Connection` objects that wrap the **same** DBAPI connection (i.e. the same database transaction) now share one version transaction, instead of getting two. This only surfaces with in-memory SQLite (which serves every `engine.connect()` from a single shared connection); on a real pool each session gets its own connection and its own transaction as before. `tests/test_sessions.py::test_multiple_connections` is therefore skipped on SQLite, where the "multiple connections" premise cannot hold.

## Tests

- `tests/test_thread_safe_uow_storage.py` — deterministic, runs on every backend: asserts the UoW lives on `connection.info`, that no global dicts remain on the manager, that state is cleared after commit/rollback, and that the pool `reset` safety net clears a lingering UoW before the next checkout.
- `tests/test_thread_safe_uow_multithreaded.py` — concurrency stress test (8 threads sharing one engine pool, insert+update+commit cycles) modelled on `test_validity_strategy_multithreaded.py`; **this is the test that races/crashes on the pre-fix code**. Skipped on SQLite (single shared connection can't exercise real concurrency); runs on postgres/mysql in CI.
- `tests/__init__.py` teardown leak check updated to inspect `connection.info`/`session.info`.

Full suite green on SQLite (`857 passed, 19 skipped`); `ruff check` and `ruff format --check` clean.

Changelog entries added to `CHANGES.rst` and `docs/changelog.md`.

Fixes: #390