### PR TITLE
fix(#392): handle join_txn_mode for version_session

### DIFF
--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -18,6 +18,18 @@ class UnitOfWork:
         self.manager = manager
         self.reset()
 
+    def create_version_session(self, session):
+        """
+        In SQLA-2.0, when using an existing connection with savepoint, Set join_transaction_mode="rollback_only"
+        to replicate the rollback() behavior from SQLA-1.4
+        """
+        try:
+            return sa.orm.session.Session(
+                bind=session.connection(), join_transaction_mode='rollback_only'
+            )
+        except TypeError:
+            return sa.orm.session.Session(bind=session.connection())
+
     def reset(self, session=None):
         """
         Reset the internal state of this UnitOfWork object. Normally this is
@@ -63,7 +75,7 @@ class UnitOfWork:
             return
 
         if not self.version_session:
-            self.version_session = sa.orm.session.Session(bind=session.connection())
+            self.version_session = self.create_version_session(session)
 
         if not self.current_transaction:
             self.create_transaction(session)
@@ -86,7 +98,7 @@ class UnitOfWork:
             return
 
         if not self.version_session:
-            self.version_session = sa.orm.session.Session(bind=session.connection())
+            self.version_session = self.create_version_session(session)
 
         self.make_versions(session)
 
@@ -110,7 +122,7 @@ class UnitOfWork:
         for key, value in args.items():
             setattr(self.current_transaction, key, value)
         if not self.version_session:
-            self.version_session = sa.orm.session.Session(bind=session.connection())
+            self.version_session = self.create_version_session(session)
         self.version_session.add(self.current_transaction)
         self.version_session.flush()
         self.version_session.expunge(self.current_transaction)

--- a/tests/test_revert.py
+++ b/tests/test_revert.py
@@ -1,5 +1,5 @@
+import pytest
 import sqlalchemy as sa
-from pytest import raises
 
 from sqlalchemy_continuum.reverter import Reverter, ReverterException
 from tests import TestCase
@@ -15,7 +15,7 @@ class TestReverter(TestCase):
         self.session.commit()
         version = article.versions[0]
 
-        with raises(ReverterException):
+        with pytest.raises(ReverterException):
             Reverter(version, relations=['unknown_relation'])
 
 
@@ -133,6 +133,17 @@ class RevertTestCase(TestCase):
         self.session.commit()
         assert len(article.tags) == 2
         assert article.tags[0].name == 'some tag'
+
+    @pytest.mark.filterwarnings('error::sqlalchemy.exc.SAWarning')
+    def test_revert_with_nested_transaction_warning(self):
+        article = self.Article(name='Some article')
+        self.session.add(article)
+        self.session.commit()
+        self.session.begin_nested()
+        article.name = 'Updated name'
+        self.session.commit()
+        assert article.versions.count() == 2
+        assert article.versions.all()[-1].name == 'Updated name'
 
 
 class TestRevertWithDefaultVersioningStrategy(RevertTestCase):


### PR DESCRIPTION
### Description

Ported https://github.com/corridor/sqlalchemy-history/pull/122 fix from sqlalchemy-history fork to this project

Fixes: #392

Description by fix original author (@ashish16052):

- SQLA 2.0 introduced new session param called `join_transaction_mode` which changes the behaviour of how existing transactions are handled

- When using a Connection with an existing SAVEPOINT: `SQLA-1.4`: the Session would propagate both commit() and rollback() calls to the underlying transaction. `SQLA-2.0`: use join_transaction_mode=control_fully to replicate the same behaviour.

- When using a Connection without an existing SAVEPOINT: `SQLA-1.4`: the Session would propagate only rollback() calls to the underlying transaction. `SQLA-2.0`: use join_transaction_mode=rollback_only to replicate the same behaviour.

- use `rollback_only` mode while creation of version_session, as it is using an existing connection, and we are never doing a commit() on it.

### Checklist

<!-- go over following points. check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

This pull request is:

- [ ] A documentation / typographical error fix
  - Good to go, no issue or tests are needed
- [x] A short code fix
  - Please include the issue number, and create an issue if none exists, which
    must include a complete example of the issue.
  - Please include: `Fixes: #<issue number>` in the commit message
  - Please include tests. A test that fails without the fix is strongly preferred.
- [ ] A new feature implementation
  - Please include the issue number, and create an issue if none exists, which
    must include a complete example of how the feature would look.
  - Please include tests and documentation updates.
