### PR TITLE
SQLModel compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,13 @@ jobs:
       - name: Install dependencies
         # Single resolution so the SQLAlchemy pin constrains the test
         # group (Flask-SQLAlchemy 3.1+ would otherwise drag in SQLAlchemy 2.x).
-        run: uv pip install -e . --group test 'sqlalchemy${{ matrix.sqlalchemy-version }}'
+        # SQLModel requires SQLAlchemy >= 2.0 — omit it on the 1.4 matrix leg.
+        run: |
+          groups=(--group test)
+          if [[ '${{ matrix.sqlalchemy-version }}' == '>=2.0' ]]; then
+            groups+=(--group test-sqlmodel)
+          fi
+          uv pip install -e . "${groups[@]}" 'sqlalchemy${{ matrix.sqlalchemy-version }}'
       - name: Run tests
         # --no-sync keeps uv run from re-syncing uv.lock over the
         # matrix-pinned SQLAlchemy version.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ covers the [feature set](intro.md#features), installation and basic usage.
 - [Queries](queries.md)
 - [Transactions](transactions.md)
 - [Native versioning](native_versioning.md)
+- [SQLModel](sqlmodel.md)
 - [Plugins](plugins.md)
 - [Configuration](configuration.md)
 - [Continuum schema](schema.md)

--- a/docs/sqlmodel.md
+++ b/docs/sqlmodel.md
@@ -1,7 +1,7 @@
 SQLModel support
 =================
 
-As of version 1.5 SQLAlchemy-Continuum supports models defined via SQLModel library.
+As of version 1.8 SQLAlchemy-Continuum supports models defined via SQLModel library.
 
 Usage
 -----
@@ -12,7 +12,7 @@ Enabling versions for SQLModel tables is identical to pure SQLAlchemy
 2. Add __versioned__ to all models you wish to add versioning to
 
 ```
-import sqlmodel
+from sqlmodel import SQLModel, Field
 import sqlalchemy as sa
 from sqlalchemy_continuum import make_versioned
 
@@ -20,13 +20,13 @@ from sqlalchemy_continuum import make_versioned
 make_versioned(user_cls=None)
 
 
-class Article(sqlmodel.SQLModel, table=True):
+class Article(SQLModel, table=True):
     __versioned__ = {}
     __tablename__ = 'article'
 
-    id: int | None = sqlmodel.Field(default=None, primary_key=True)
-    name: str = sqlmodel.Field(max_length=255, sa_type=sa.Unicode(255))
-    content: str = sqlmodel.Field(sa_type=sa.UnicodeText)
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(max_length=255, sa_type=sa.Unicode(255))
+    content: str = Field(sa_type=sa.UnicodeText)
 
 
 # after you have defined all your models, call configure_mappers:

--- a/docs/sqlmodel.md
+++ b/docs/sqlmodel.md
@@ -1,0 +1,41 @@
+SQLModel support
+=================
+
+As of version 1.5 SQLAlchemy-Continuum supports models defined via SQLModel library.
+
+Usage
+-----
+
+Enabling versions for SQLModel tables is identical to pure SQLAlchemy
+
+1. Call make_versioned() before your models are defined.
+2. Add __versioned__ to all models you wish to add versioning to
+
+```
+import sqlmodel
+import sqlalchemy as sa
+from sqlalchemy_continuum import make_versioned
+
+
+make_versioned(user_cls=None)
+
+
+class Article(sqlmodel.SQLModel, table=True):
+    __versioned__ = {}
+    __tablename__ = 'article'
+
+    id: int | None = sqlmodel.Field(default=None, primary_key=True)
+    name: str = sqlmodel.Field(max_length=255, sa_type=sa.Unicode(255))
+    content: str = sqlmodel.Field(sa_type=sa.UnicodeText)
+
+
+# after you have defined all your models, call configure_mappers:
+sa.orm.configure_mappers()
+```
+
+Non supported features
+----------------------
+
+Following features are not supported with SQLModel
+
+- `base_classes` parameter for `__versioned__` attribute

--- a/docs/sqlmodel.md
+++ b/docs/sqlmodel.md
@@ -3,6 +3,14 @@ SQLModel support
 
 As of version 1.8 SQLAlchemy-Continuum supports models defined via SQLModel library.
 
+Notice that using SQLModel requires SQLAlchemy >= 2.0. By enabling an optional dependency group `sqlmodel`,
+you will get the check for required SQLAlchemy version.
+
+
+```bash
+pip install sqlalchemy-continuum[sqlmodel]
+```
+
 Usage
 -----
 

--- a/docs/sqlmodel.rst
+++ b/docs/sqlmodel.rst
@@ -1,0 +1,42 @@
+SQLModel support
+=================
+
+As of version 1.5 SQLAlchemy-Continuum supports models defined via SQLModel library.
+
+Usage
+-----
+
+Enabling versions for SQLModel tables is identical to pure SQLAlchemy
+
+1. Call make_versioned() before your models are defined.
+2. Add __versioned__ to all models you wish to add versioning to
+
+::
+
+    from sqlmodel import SQLModel, Field
+    import sqlalchemy as sa
+    from sqlalchemy_continuum import make_versioned
+
+
+    make_versioned(user_cls=None)
+
+
+    class Article(SQLModel, table=True):
+        __versioned__ = {}
+        __tablename__ = 'article'
+
+        id: int | None = Field(default=None, primary_key=True)
+        name: str = Field(max_length=255, sa_type=sa.Unicode(255))
+        content: str = Field(sa_type=sa.UnicodeText)
+
+
+    # after you have defined all your models, call configure_mappers:
+    sa.orm.configure_mappers()
+
+
+Non supported features
+----------------------
+
+Following features are not supported with SQLModel
+
+- `base_classes` parameter for `__versioned__` attribute

--- a/docs/sqlmodel.rst
+++ b/docs/sqlmodel.rst
@@ -3,6 +3,15 @@ SQLModel support
 
 As of version 1.5 SQLAlchemy-Continuum supports models defined via SQLModel library.
 
+Notice that using SQLModel requires SQLAlchemy >= 2.0. By enabling an optional dependency group `sqlmodel`,
+you will get the check for required SQLAlchemy version.
+
+
+```bash
+pip install sqlalchemy-continuum[sqlmodel]
+```
+
+
 Usage
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,3 +133,6 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["--strict-config", "--strict-markers"]
+filterwarnings = [
+    "ignore:\\s*.*You probably want to use.*session\\.query.*:DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
 flask = ["Flask>=2.0"]
 flask-login = ["Flask-Login>=0.6"]
 flask-sqlalchemy = ["Flask-SQLAlchemy>=3.0"]
-sqlmodel = ['SQLModel>=0.0.24']
 
 [project.urls]
 Homepage = "https://github.com/sqlalchemy-continuum/sqlalchemy-continuum"
@@ -113,6 +112,7 @@ test = [
     "Flask>=2.0",
     "Flask-Login>=0.6",
     "Flask-SQLAlchemy>=3.0",
+    "SQLModel>=0.0.24",
     "packaging",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 flask = ["Flask>=2.0"]
 flask-login = ["Flask-Login>=0.6"]
 flask-sqlalchemy = ["Flask-SQLAlchemy>=3.0"]
+sqlmodel = ['SQLModel>=0.0.24']
 
 [project.urls]
 Homepage = "https://github.com/sqlalchemy-continuum/sqlalchemy-continuum"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 flask = ["Flask>=2.0"]
 flask-login = ["Flask-Login>=0.6"]
 flask-sqlalchemy = ["Flask-SQLAlchemy>=3.0"]
+sqlmodel = ["SQLModel>=0.0.24"]
 
 [project.urls]
 Homepage = "https://github.com/sqlalchemy-continuum/sqlalchemy-continuum"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,11 @@ test = [
     "Flask>=2.0",
     "Flask-Login>=0.6",
     "Flask-SQLAlchemy>=3.0",
-    "SQLModel>=0.0.24",
     "packaging",
+]
+# SQLModel requires SQLAlchemy >= 2.0; install only on SA 2.x test legs (see tox/CI).
+test-sqlmodel = [
+    "SQLModel>=0.0.24",
 ]
 docs = [
     "zensical>=0.0.46",
@@ -125,6 +128,7 @@ lint = [
 ]
 dev = [
     { include-group = "test" },
+    { include-group = "test-sqlmodel" },
     { include-group = "docs" },
     { include-group = "lint" },
     "tox>=4.27",

--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -10,6 +10,7 @@ from .dialects.postgresql import create_versioning_trigger_listeners
 from .model_builder import ModelBuilder
 from .relationship_builder import RelationshipBuilder
 from .table_builder import TableBuilder
+from .utils import declarative_base_resolver
 
 
 def prevent_reentry(handler):
@@ -146,7 +147,7 @@ class Builder:
     def build_transaction_class(self):
         if self.manager.pending_classes:
             cls = self.manager.pending_classes[0]
-            self.manager.declarative_base = get_declarative_base(cls)
+            self.manager.declarative_base = declarative_base_resolver(cls)
             self.manager.create_transaction_model()
             self.manager.plugins.after_build_tx_class(self.manager)
 
@@ -167,7 +168,6 @@ class Builder:
         """
         if not self.manager.options['versioning']:
             return
-
         self.build_triggers()
         self.build_tables()
         self.build_transaction_class()

--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -5,7 +5,6 @@ from inspect import getmro
 import sqlalchemy as sa
 from sqlalchemy.orm.descriptor_props import ConcreteInheritedProperty
 
-from ._compat import get_declarative_base
 from .dialects.postgresql import create_versioning_trigger_listeners
 from .model_builder import ModelBuilder
 from .relationship_builder import RelationshipBuilder

--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -4,8 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import column_property
 
-from ._compat import get_declarative_base
-from .utils import adapt_columns, option
+from .utils import adapt_columns, option, declarative_base_resolver
 from .version import VersionClassBase
 
 
@@ -31,7 +30,11 @@ def get_base_class(manager, model):
     """
     Returns all base classes for history model.
     """
-    return option(model, 'base_classes') or (get_declarative_base(model),)
+    return (
+        option(model, 'base_classes')
+        or
+        (declarative_base_resolver(model), )
+    )
 
 
 def version_base(manager, parent_cls, base_class_factory=None):

--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -30,11 +30,7 @@ def get_base_class(manager, model):
     """
     Returns all base classes for history model.
     """
-    return (
-        option(model, 'base_classes')
-        or
-        (declarative_base_resolver(model), )
-    )
+    return option(model, 'base_classes') or (declarative_base_resolver(model),)
 
 
 def version_base(manager, parent_cls, base_class_factory=None):

--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import column_property
 
-from .utils import adapt_columns, option, declarative_base_resolver
+from .utils import adapt_columns, declarative_base_resolver, option
 from .version import VersionClassBase
 
 

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -10,6 +10,7 @@ from .dialects.postgresql import (
 )
 from .exc import ImproperlyConfigured
 from .factory import ModelFactory
+from .utils import declarative_base_resolver
 
 
 def utc_now():
@@ -138,7 +139,7 @@ class TransactionFactory(ModelFactory):
 
             if manager.user_cls:
                 user_cls = manager.user_cls
-                Base = manager.declarative_base
+                Base = declarative_base_resolver(manager.declarative_base)
                 registry = Base.registry._class_registry
 
                 if isinstance(user_cls, str):

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -10,6 +10,7 @@ from ._compat import (
     get_primary_keys,
     identity,
     naturally_equivalent,
+    get_declarative_base
 )
 from .exc import ClassNotVersioned
 
@@ -411,6 +412,24 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
         if isinstance(col, sa.Column):
             table = version_table(col.table)
             return table.c.get(col.key)
+
+
+class DeclarativeBaseResolver:
+    """Resolves declarative base class from either SQLModel or sqlalchemy registry."""
+    _sa_base = None
+
+    def __call__(self, model):
+        if hasattr(model, "registry"):
+            # This is NOT SQLModel
+            return get_declarative_base(model)
+        else:
+            # SQLModel compatibility
+            if DeclarativeBaseResolver._sa_base is None:
+                DeclarativeBaseResolver._sa_base = model._sa_registry.generate_base()
+            return DeclarativeBaseResolver._sa_base
+
+
+declarative_base_resolver = DeclarativeBaseResolver()
 
 
 def adapt_columns(expr):

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -10,7 +10,7 @@ from ._compat import (
     get_primary_keys,
     identity,
     naturally_equivalent,
-    get_declarative_base
+    get_declarative_base,
 )
 from .exc import ClassNotVersioned
 
@@ -416,10 +416,11 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
 
 class DeclarativeBaseResolver:
     """Resolves declarative base class from either SQLModel or sqlalchemy registry."""
+
     _sa_base = None
 
     def __call__(self, model):
-        if hasattr(model, "registry"):
+        if hasattr(model, 'registry'):
             # This is NOT SQLModel
             return get_declarative_base(model)
         else:

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -7,10 +7,10 @@ from sqlalchemy.orm.attributes import get_history
 from sqlalchemy.orm.util import AliasedClass
 
 from ._compat import (
+    get_declarative_base,
     get_primary_keys,
     identity,
     naturally_equivalent,
-    get_declarative_base,
 )
 from .exc import ClassNotVersioned
 

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,0 +1,102 @@
+from copy import copy
+import os
+import pathlib
+
+import sqlmodel
+from sqlmodel import Field, Relationship, Session
+import sqlalchemy as sa
+from sqlalchemy_continuum import make_versioned
+from sqlalchemy_continuum import versioning_manager
+
+from sqlalchemy_continuum.exc import ClassNotVersioned
+from sqlalchemy_continuum.transaction import TransactionFactory
+from sqlalchemy_continuum.utils import version_class
+from tests import TestCase, get_driver_name, get_url_from_driver
+
+
+models_path = pathlib.Path(__file__).parent.absolute() / "_models.py"
+
+
+class SQLModelTestCase(TestCase):
+
+    def setup_method(self, method):
+        self.Model = sqlmodel.SQLModel
+        make_versioned(user_cls=self.user_cls)
+
+        driver = os.environ.get("DB", "sqlite")
+        self.driver = get_driver_name(driver)
+        versioning_manager.plugins = self.plugins
+        versioning_manager.transaction_cls = TransactionFactory()
+        versioning_manager.user_cls = self.user_cls
+
+        self.engine = sa.create_engine(get_url_from_driver(self.driver), echo=True)
+        # self.engine.echo = True
+        self.create_models()
+        sa.orm.configure_mappers()
+
+        if hasattr(self, "Article"):
+            try:
+                self.ArticleVersion = version_class(self.Article)
+            except ClassNotVersioned:
+                pass
+        if hasattr(self, "Tag"):
+            try:
+                self.TagVersion = version_class(self.Tag)
+            except ClassNotVersioned:
+                pass
+
+        self.connection = self.engine.connect()
+        self.session = Session(self.engine, autoflush=False)
+
+        if driver == "postgres-native":
+            self.session.execute(sa.text("CREATE EXTENSION IF NOT EXISTS hstore"))
+
+        # Run any other custom SQL in here
+        self.create_schema("other")
+        self.session.commit()
+
+        # Using an engine here instead of connection will call commit for us,
+        # which lets us use the same syntax for 1.4 and 2.0
+        self.Model.metadata.create_all(self.engine)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
+        for entity in (
+            "Article",
+            "Tag",
+            "ArticleVersion",
+            "TagVersion",
+            "User",
+            "ArticleTagLink",
+            "ArticleReferences",
+        ):
+            if hasattr(self, entity):
+                self.Model.metadata.remove(getattr(self, entity).__table__)
+        self.Model.metadata.clear()
+        self.Model._sa_registry._class_registry.clear()
+
+    def create_models(self):
+
+        class Article(self.Model, table=True):
+            __tablename__ = "article"
+            __versioned__ = {}
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(
+                sa_type=sa.UnicodeText, default=None, nullable=True
+            )
+            tags: list["Tag"] = Relationship(back_populates="article")
+
+        class Tag(self.Model, table=True):
+            __tablename__ = "tag"
+            __versioned__ = {}
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            article_id: int | None = Field(default=None, foreign_key="article.id")
+            article: Article = Relationship(back_populates="tags")
+
+        self.Article = Article
+        self.Tag = Tag

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,7 +1,5 @@
-from copy import copy
 import os
-import pathlib
-
+from typing import Union
 import sqlmodel
 from sqlmodel import Field, Relationship, Session
 import sqlalchemy as sa
@@ -14,16 +12,12 @@ from sqlalchemy_continuum.utils import version_class
 from tests import TestCase, get_driver_name, get_url_from_driver
 
 
-models_path = pathlib.Path(__file__).parent.absolute() / "_models.py"
-
-
 class SQLModelTestCase(TestCase):
-
     def setup_method(self, method):
         self.Model = sqlmodel.SQLModel
         make_versioned(user_cls=self.user_cls)
 
-        driver = os.environ.get("DB", "sqlite")
+        driver = os.environ.get('DB', 'sqlite')
         self.driver = get_driver_name(driver)
         versioning_manager.plugins = self.plugins
         versioning_manager.transaction_cls = TransactionFactory()
@@ -34,12 +28,12 @@ class SQLModelTestCase(TestCase):
         self.create_models()
         sa.orm.configure_mappers()
 
-        if hasattr(self, "Article"):
+        if hasattr(self, 'Article'):
             try:
                 self.ArticleVersion = version_class(self.Article)
             except ClassNotVersioned:
                 pass
-        if hasattr(self, "Tag"):
+        if hasattr(self, 'Tag'):
             try:
                 self.TagVersion = version_class(self.Tag)
             except ClassNotVersioned:
@@ -48,11 +42,11 @@ class SQLModelTestCase(TestCase):
         self.connection = self.engine.connect()
         self.session = Session(self.engine, autoflush=False)
 
-        if driver == "postgres-native":
-            self.session.execute(sa.text("CREATE EXTENSION IF NOT EXISTS hstore"))
+        if driver == 'postgres-native':
+            self.session.execute(sa.text('CREATE EXTENSION IF NOT EXISTS hstore'))
 
         # Run any other custom SQL in here
-        self.create_schema("other")
+        self.create_schema('other')
         self.session.commit()
 
         # Using an engine here instead of connection will call commit for us,
@@ -62,13 +56,13 @@ class SQLModelTestCase(TestCase):
     def teardown_method(self, method):
         super().teardown_method(method)
         for entity in (
-            "Article",
-            "Tag",
-            "ArticleVersion",
-            "TagVersion",
-            "User",
-            "ArticleTagLink",
-            "ArticleReferences",
+            'Article',
+            'Tag',
+            'ArticleVersion',
+            'TagVersion',
+            'User',
+            'ArticleTagLink',
+            'ArticleReferences',
         ):
             if hasattr(self, entity):
                 self.Model.metadata.remove(getattr(self, entity).__table__)
@@ -76,9 +70,8 @@ class SQLModelTestCase(TestCase):
         self.Model._sa_registry._class_registry.clear()
 
     def create_models(self):
-
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
@@ -87,16 +80,16 @@ class SQLModelTestCase(TestCase):
             description: str = Field(
                 sa_type=sa.UnicodeText, default=None, nullable=True
             )
-            tags: list["Tag"] = Relationship(back_populates="article")
+            tags: list['Tag'] = Relationship(back_populates='article')
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
             __versioned__ = {}
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
-            article_id: int | None = Field(default=None, foreign_key="article.id")
-            article: Article = Relationship(back_populates="tags")
+            article_id: Union[int, None] = Field(default=None, foreign_key='article.id')
+            article: Article = Relationship(back_populates='tags')
 
         self.Article = Article
         self.Tag = Tag

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,15 +1,19 @@
 import os
 from typing import Union
-import sqlmodel
-from sqlmodel import Field, Relationship, Session
-import sqlalchemy as sa
-from sqlalchemy_continuum import make_versioned
-from sqlalchemy_continuum import versioning_manager
 
+import pytest
+import sqlalchemy as sa
+
+from sqlalchemy_continuum import make_versioned, versioning_manager
 from sqlalchemy_continuum.exc import ClassNotVersioned
 from sqlalchemy_continuum.transaction import TransactionFactory
 from sqlalchemy_continuum.utils import version_class
 from tests import TestCase, get_driver_name, get_url_from_driver
+
+sqlmodel = pytest.importorskip('sqlmodel')
+Field = sqlmodel.Field
+Relationship = sqlmodel.Relationship
+Session = sqlmodel.Session
 
 
 class SQLModelTestCase(TestCase):
@@ -88,7 +92,7 @@ class SQLModelTestCase(TestCase):
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
-            article_id: Union[int, None] = Field(default=None, foreign_key='article.id')
+            article_id: int | None = Field(default=None, foreign_key='article.id')
             article: Article = Relationship(back_populates='tags')
 
         self.Article = Article

--- a/tests/sqlmodel/relationships/test_many_to_many_relations.py
+++ b/tests/sqlmodel/relationships/test_many_to_many_relations.py
@@ -1,5 +1,5 @@
-from typing import Self
 import pytest
+from typing import Union
 from pytest import mark
 import sqlalchemy as sa
 from sqlmodel import Field, Relationship
@@ -11,35 +11,34 @@ from tests.sqlmodel import SQLModelTestCase
 
 class ManyToManyRelationshipsTestCase(SQLModelTestCase):
     def create_models(self):
-
         class ArticleTagLink(self.Model, table=True):
-            __tablename__ = "article_tag"
-            article_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_tag'
+            article_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: int | None = Field(
-                default=None, foreign_key="tag.id", primary_key=True
+            tag_id: Union[int, None] = Field(
+                default=None, foreign_key='tag.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            tags: list["Tag"] = Relationship(
-                back_populates="articles", link_model=ArticleTagLink
+            content: str = Field(default='')
+            tags: list['Tag'] = Relationship(
+                back_populates='articles', link_model=ArticleTagLink
             )
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
-                back_populates="tags", link_model=ArticleTagLink
+                back_populates='tags', link_model=ArticleTagLink
             )
 
         self.Article = Article
@@ -47,29 +46,29 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
         self.ArticleTagLink = ArticleTagLink
 
     def test_version_relations(self):
-        article = self.Article(name="Some article", content="Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         assert not article.versions[0].tags
 
     def test_single_insert(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
         assert len(article.versions[0].tags) == 1
 
     def test_unrelated_change(self):
-        tag1 = self.Tag(name="some tag")
-        tag2 = self.Tag(name="some tag2")
+        tag1 = self.Tag(name='some tag')
+        tag2 = self.Tag(name='some tag2')
 
         self.session.add(tag1)
         self.session.add(tag2)
         self.session.commit()
 
         article1 = self.Article(
-            name="Some article",
+            name='Some article',
         )
         article1.tags.append(tag1)
 
@@ -77,78 +76,78 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
         self.session.commit()
 
         article2 = self.Article()
-        article2.name = "Some article2"
+        article2.name = 'Some article2'
         article2.tags.append(tag1)
 
         self.session.add(article2)
         self.session.commit()
 
-        article1.name = "Some other name"
+        article1.name = 'Some other name'
         self.session.commit()
 
         assert len(article1.versions[1].tags) == 1
 
     def test_multi_insert(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
-        article.tags.append(self.Tag(name="another tag"))
+        article.tags.append(self.Tag(name='another tag'))
         self.session.add(article)
         self.session.commit()
         assert len(article.versions[0].tags) == 2
 
     def test_collection_with_multiple_entries(self):
-        article = self.Article(name="Some article", content="Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
-        article.tags = [self.Tag(name="some tag"), self.Tag(name="another tag")]
+        article.tags = [self.Tag(name='some tag'), self.Tag(name='another tag')]
         self.session.commit()
         assert len(article.versions[0].tags) == 2
 
     def test_delete_single_association(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
         article.tags.remove(tag)
-        article.name = "Updated name"
+        article.name = 'Updated name'
         self.session.commit()
         tags = article.versions[1].tags
         assert len(tags) == 0
 
     def test_delete_multiple_associations(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
-        tag2 = self.Tag(name="another tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
+        tag2 = self.Tag(name='another tag')
         article.tags.append(tag)
         article.tags.append(tag2)
         self.session.add(article)
         self.session.commit()
         article.tags.remove(tag)
         article.tags.remove(tag2)
-        article.name = "Updated name"
+        article.name = 'Updated name'
         self.session.commit()
         assert len(article.versions[1].tags) == 0
 
     def test_remove_node_but_not_the_link(self):
-        article = self.Article(name="Some article", content="Some content")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
         self.session.delete(tag)
-        article.name = "Updated name"
+        article.name = 'Updated name'
         self.session.commit()
         tags = article.versions[1].tags
         assert len(tags) == 0
 
     def test_multiple_parent_objects_added_within_same_transaction(self):
-        article = self.Article(name="Some article")
-        tag = self.Tag(name="some tag")
+        article = self.Article(name='Some article')
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
-        article2 = self.Article(name="Some article")
-        tag2 = self.Tag(name="some tag")
+        article2 = self.Article(name='Some article')
+        tag2 = self.Tag(name='some tag')
         article2.tags.append(tag2)
         self.session.add(article2)
         self.session.commit()
@@ -159,29 +158,29 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
         assert tags == [tag.versions[0]]
 
     def test_relations_with_varying_transactions(self):
-        if self.driver == "mysql" and self.connection.dialect.server_version_info < (
+        if self.driver == 'mysql' and self.connection.dialect.server_version_info < (
             5,
             6,
         ):
             pytest.skip()
 
         # one article with one tag
-        article = self.Article(name="Some article")
-        tag1 = self.Tag(name="some tag")
+        article = self.Article(name='Some article')
+        tag1 = self.Tag(name='some tag')
         article.tags.append(tag1)
         self.session.add(article)
         self.session.commit()
 
         # update article and tag, add a 2nd tag
-        tag2 = self.Tag(name="some other tag")
+        tag2 = self.Tag(name='some other tag')
         article.tags.append(tag2)
-        tag1.name = "updated tag1"
-        article.name = "updated article"
+        tag1.name = 'updated tag1'
+        article.name = 'updated article'
         self.session.commit()
 
         # update article and first tag only
-        tag1.name = "updated tag1 x2"
-        article.name = "updated article x2"
+        tag1.name = 'updated tag1 x2'
+        article.name = 'updated article x2'
         self.session.commit()
 
         assert len(article.versions[0].tags) == 1
@@ -202,36 +201,37 @@ create_test_cases(ManyToManyRelationshipsTestCase)
 class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
     def create_models(self):
         class ArticleTagLink(self.Model, table=True):
-            __tablename__ = "article_tag"
-            article_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_tag'
+            article_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: int | None = Field(
-                default=None, foreign_key="tag.id", primary_key=True
+            tag_id: Union[int, None] = Field(
+                default=None, foreign_key='tag.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            tags: list["Tag"] = Relationship(
-                back_populates="articles", link_model=ArticleTagLink,
-                sa_relationship_kwargs={"viewonly": True}
+            content: str = Field(default='')
+            tags: list['Tag'] = Relationship(
+                back_populates='articles',
+                link_model=ArticleTagLink,
+                sa_relationship_kwargs={'viewonly': True},
             )
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
-                back_populates="tags",
+                back_populates='tags',
                 link_model=ArticleTagLink,
-                sa_relationship_kwargs={"viewonly": True}
+                sa_relationship_kwargs={'viewonly': True},
             )
 
         self.ArticleTagLink = ArticleTagLink
@@ -243,41 +243,38 @@ class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
 
 
 class TestManyToManySelfReferential(SQLModelTestCase):
-
     def create_models(self):
         class ArticleReferences(self.Model, table=True):
-            __tablename__ = "article_references"
-            referring_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_references'
+            referring_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            referred_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            referred_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            references: list["Article"] = Relationship(
+            content: str = Field(default='')
+            references: list['Article'] = Relationship(
                 link_model=ArticleReferences,
                 sa_relationship_kwargs={
-                    "primaryjoin": "Article.id == ArticleReferences.referring_id",
-                    "secondaryjoin": "Article.id == ArticleReferences.referred_id",
-                    "backref": "cited_by",
-                  }
+                    'primaryjoin': 'Article.id == ArticleReferences.referring_id',
+                    'secondaryjoin': 'Article.id == ArticleReferences.referred_id',
+                    'backref': 'cited_by',
+                },
             )
-
 
         self.Article = Article
         self.ArticleReferences = ArticleReferences
 
     def test_single_insert(self):
-
-        article = self.Article(name="article")
-        reference1 = self.Article(name="referred article 1")
+        article = self.Article(name='article')
+        reference1 = self.Article(name='referred article 1')
         article.references.append(reference1)
         self.session.add(article)
         self.session.commit()
@@ -289,29 +286,29 @@ class TestManyToManySelfReferential(SQLModelTestCase):
         assert article.versions[0] in reference1.versions[0].cited_by
 
     def test_multiple_inserts_over_multiple_transactions(self):
-        if self.driver == "mysql" and self.connection.dialect.server_version_info < (
+        if self.driver == 'mysql' and self.connection.dialect.server_version_info < (
             5,
             6,
         ):
             pytest.skip()
 
         # create 1 article with 1 reference
-        article = self.Article(name="article")
-        reference1 = self.Article(name="reference 1")
+        article = self.Article(name='article')
+        reference1 = self.Article(name='reference 1')
         article.references.append(reference1)
         self.session.add(article)
         self.session.commit()
 
         # update existing, add a 2nd reference
-        article.name = "Updated article"
-        reference1.name = "Updated reference 1"
-        reference2 = self.Article(name="reference 2")
+        article.name = 'Updated article'
+        reference1.name = 'Updated reference 1'
+        reference2 = self.Article(name='reference 2')
         article.references.append(reference2)
         self.session.commit()
 
         # update only the article and reference 1
-        article.name = "Updated article x2"
-        reference1.name = "Updated reference 1 x2"
+        article.name = 'Updated article x2'
+        reference1.name = 'Updated reference 1 x2'
         self.session.commit()
 
         assert len(article.versions[1].references) == 2
@@ -335,29 +332,29 @@ class TestManyToManySelfReferential(SQLModelTestCase):
 class TestManyToManySelfReferentialInOtherSchema(SQLModelTestCase):
     def create_models(self):
         class Article(self.Model):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
-            __table_args__ = {"schema": "other"}
+            __table_args__ = {'schema': 'other'}
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.Unicode(255))
 
         article_references = sa.Table(
-            "article_references",
+            'article_references',
             self.Model.metadata,
             sa.Column(
-                "referring_id",
+                'referring_id',
                 sa.Integer,
-                sa.ForeignKey("other.article.id"),
+                sa.ForeignKey('other.article.id'),
                 primary_key=True,
             ),
             sa.Column(
-                "referred_id",
+                'referred_id',
                 sa.Integer,
-                sa.ForeignKey("other.article.id"),
+                sa.ForeignKey('other.article.id'),
                 primary_key=True,
             ),
-            schema="other",
+            schema='other',
         )
 
         Article.references = sa.orm.relationship(
@@ -365,7 +362,7 @@ class TestManyToManySelfReferentialInOtherSchema(SQLModelTestCase):
             secondary=article_references,
             primaryjoin=Article.id == article_references.c.referring_id,
             secondaryjoin=Article.id == article_references.c.referred_id,
-            backref="cited_by",
+            backref='cited_by',
         )
 
         self.Article = Article
@@ -375,38 +372,38 @@ class TestManyToManySelfReferentialInOtherSchema(SQLModelTestCase):
 class ManyToManyRelationshipsInOtherSchemaTestCase(SQLModelTestCase):
     def create_models(self):
         class Article(self.Model):
-            __tablename__ = "article"
-            __versioned__ = {"base_classes": (self.Model,)}
-            __table_args__ = {"schema": "other"}
+            __tablename__ = 'article'
+            __versioned__ = {'base_classes': (self.Model,)}
+            __table_args__ = {'schema': 'other'}
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.Unicode(255))
 
         article_tag = sa.Table(
-            "article_tag",
+            'article_tag',
             self.Model.metadata,
             sa.Column(
-                "article_id",
+                'article_id',
                 sa.Integer,
-                sa.ForeignKey("other.article.id"),
+                sa.ForeignKey('other.article.id'),
                 primary_key=True,
             ),
             sa.Column(
-                "tag_id", sa.Integer, sa.ForeignKey("other.tag.id"), primary_key=True
+                'tag_id', sa.Integer, sa.ForeignKey('other.tag.id'), primary_key=True
             ),
-            schema="other",
+            schema='other',
         )
 
         class Tag(self.Model):
-            __tablename__ = "tag"
-            __versioned__ = {"base_classes": (self.Model,)}
-            __table_args__ = {"schema": "other"}
+            __tablename__ = 'tag'
+            __versioned__ = {'base_classes': (self.Model,)}
+            __table_args__ = {'schema': 'other'}
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.Unicode(255))
 
         Tag.articles = sa.orm.relationship(
-            Article, secondary=article_tag, backref="tags"
+            Article, secondary=article_tag, backref='tags'
         )
 
         self.Article = Article

--- a/tests/sqlmodel/relationships/test_many_to_many_relations.py
+++ b/tests/sqlmodel/relationships/test_many_to_many_relations.py
@@ -1,10 +1,11 @@
-import pytest
 from typing import Union
-from pytest import mark
-import sqlalchemy as sa
-from sqlmodel import Field, Relationship
-from sqlalchemy_continuum import versioning_manager
 
+import pytest
+import sqlalchemy as sa
+from pytest import mark
+from sqlmodel import Field, Relationship
+
+from sqlalchemy_continuum import versioning_manager
 from tests import create_test_cases
 from tests.sqlmodel import SQLModelTestCase
 
@@ -13,10 +14,10 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
     def create_models(self):
         class ArticleTagLink(self.Model, table=True):
             __tablename__ = 'article_tag'
-            article_id: Union[int, None] = Field(
+            article_id: int | None = Field(
                 default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: Union[int, None] = Field(
+            tag_id: int | None = Field(
                 default=None, foreign_key='tag.id', primary_key=True
             )
 
@@ -24,7 +25,7 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             content: str = Field(default='')
             tags: list['Tag'] = Relationship(
@@ -35,7 +36,7 @@ class ManyToManyRelationshipsTestCase(SQLModelTestCase):
             __tablename__ = 'tag'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
                 back_populates='tags', link_model=ArticleTagLink
@@ -202,10 +203,10 @@ class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
     def create_models(self):
         class ArticleTagLink(self.Model, table=True):
             __tablename__ = 'article_tag'
-            article_id: Union[int, None] = Field(
+            article_id: int | None = Field(
                 default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: Union[int, None] = Field(
+            tag_id: int | None = Field(
                 default=None, foreign_key='tag.id', primary_key=True
             )
 
@@ -213,7 +214,7 @@ class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             content: str = Field(default='')
             tags: list['Tag'] = Relationship(
@@ -226,7 +227,7 @@ class TestManyToManyRelationshipWithViewOnly(SQLModelTestCase):
             __tablename__ = 'tag'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
                 back_populates='tags',
@@ -246,10 +247,10 @@ class TestManyToManySelfReferential(SQLModelTestCase):
     def create_models(self):
         class ArticleReferences(self.Model, table=True):
             __tablename__ = 'article_references'
-            referring_id: Union[int, None] = Field(
+            referring_id: int | None = Field(
                 default=None, foreign_key='article.id', primary_key=True
             )
-            referred_id: Union[int, None] = Field(
+            referred_id: int | None = Field(
                 default=None, foreign_key='article.id', primary_key=True
             )
 
@@ -257,7 +258,7 @@ class TestManyToManySelfReferential(SQLModelTestCase):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             content: str = Field(default='')
             references: list['Article'] = Relationship(

--- a/tests/sqlmodel/relationships/test_non_versioned_classes.py
+++ b/tests/sqlmodel/relationships/test_non_versioned_classes.py
@@ -1,0 +1,101 @@
+from sqlmodel import Field, Relationship
+from tests.sqlmodel import SQLModelTestCase
+import sqlalchemy as sa
+
+
+class TestRelationshipToNonVersionedClass(SQLModelTestCase):
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+
+            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            articles: list["Article"] = Relationship(back_populates="author")
+
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(sa_type=sa.UnicodeText, default="")
+            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
+            author: User = Relationship(back_populates="articles")
+
+        self.Article = Article
+        self.User = User
+
+    def test_single_insert(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+
+        assert isinstance(article.versions[0].author, self.User)
+
+    def test_change_relationship(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        user = self.User(name=u'Some user')
+        self.session.add(article)
+        self.session.add(user)
+        self.session.commit()
+
+        assert article.versions.count() == 1
+        article.author = user
+        self.session.commit()
+        assert article.versions.count() == 2
+
+
+class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
+    def create_models(self):
+
+        class ArticleTagLink(self.Model, table=True):
+            __tablename__ = "article_tag"
+            article_id: int | None = Field(
+                default=None, foreign_key="article.id", primary_key=True
+            )
+            tag_id: int | None = Field(
+                default=None, foreign_key="tag.id", primary_key=True
+            )
+
+        class Article(self.Model, table=True):
+            __tablename__ = "article"
+            __versioned__ = {}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(max_length=255)
+            content: str = Field(default="")
+            tags: list["Tag"] = Relationship(
+                back_populates="articles", link_model=ArticleTagLink
+            )
+
+        class Tag(self.Model, table=True):
+            __tablename__ = "tag"
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(max_length=255)
+            articles: list[Article] = Relationship(
+                back_populates="tags", link_model=ArticleTagLink
+            )
+
+        self.Article = Article
+        self.Tag = Tag
+        self.ArticleTagLink = ArticleTagLink
+
+
+    def test_single_insert(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        tag = self.Tag(name=u'some tag')
+        article.tags.append(tag)
+        self.session.add(article)
+        self.session.commit()
+        assert len(article.versions[0].tags) == 1
+        assert isinstance(article.versions[0].tags[0], self.Tag)

--- a/tests/sqlmodel/relationships/test_non_versioned_classes.py
+++ b/tests/sqlmodel/relationships/test_non_versioned_classes.py
@@ -1,4 +1,5 @@
 from sqlmodel import Field, Relationship
+from typing import Union
 from tests.sqlmodel import SQLModelTestCase
 import sqlalchemy as sa
 
@@ -8,29 +9,33 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
         class User(self.Model, table=True):
             __tablename__ = 'user'
 
-            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            id: Union[int, None] = Field(
+                sa_type=sa.Integer, default=None, primary_key=True
+            )
             name: str = Field(sa_type=sa.Unicode(255))
-            articles: list["Article"] = Relationship(back_populates="author")
+            articles: list['Article'] = Relationship(back_populates='author')
 
         class Article(self.Model, table=True):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
-            description: str = Field(sa_type=sa.UnicodeText, default="")
-            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
-            author: User = Relationship(back_populates="articles")
+            description: str = Field(sa_type=sa.UnicodeText, default='')
+            author_id: Union[int, None] = Field(
+                sa_type=sa.Integer, foreign_key='user.id'
+            )
+            author: User = Relationship(back_populates='articles')
 
         self.Article = Article
         self.User = User
 
     def test_single_insert(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
-        user = self.User(name=u'Some user')
+        article.name = 'Some article'
+        article.content = 'Some content'
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
@@ -39,9 +44,9 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
 
     def test_change_relationship(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
-        user = self.User(name=u'Some user')
+        article.name = 'Some article'
+        article.content = 'Some content'
+        user = self.User(name='Some user')
         self.session.add(article)
         self.session.add(user)
         self.session.commit()
@@ -54,46 +59,44 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
 
 class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
     def create_models(self):
-
         class ArticleTagLink(self.Model, table=True):
-            __tablename__ = "article_tag"
-            article_id: int | None = Field(
-                default=None, foreign_key="article.id", primary_key=True
+            __tablename__ = 'article_tag'
+            article_id: Union[int, None] = Field(
+                default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: int | None = Field(
-                default=None, foreign_key="tag.id", primary_key=True
+            tag_id: Union[int, None] = Field(
+                default=None, foreign_key='tag.id', primary_key=True
             )
 
         class Article(self.Model, table=True):
-            __tablename__ = "article"
+            __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
-            content: str = Field(default="")
-            tags: list["Tag"] = Relationship(
-                back_populates="articles", link_model=ArticleTagLink
+            content: str = Field(default='')
+            tags: list['Tag'] = Relationship(
+                back_populates='articles', link_model=ArticleTagLink
             )
 
         class Tag(self.Model, table=True):
-            __tablename__ = "tag"
+            __tablename__ = 'tag'
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
-                back_populates="tags", link_model=ArticleTagLink
+                back_populates='tags', link_model=ArticleTagLink
             )
 
         self.Article = Article
         self.Tag = Tag
         self.ArticleTagLink = ArticleTagLink
 
-
     def test_single_insert(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
-        tag = self.Tag(name=u'some tag')
+        article.name = 'Some article'
+        article.content = 'Some content'
+        tag = self.Tag(name='some tag')
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()

--- a/tests/sqlmodel/relationships/test_non_versioned_classes.py
+++ b/tests/sqlmodel/relationships/test_non_versioned_classes.py
@@ -1,7 +1,9 @@
-from sqlmodel import Field, Relationship
 from typing import Union
-from tests.sqlmodel import SQLModelTestCase
+
 import sqlalchemy as sa
+from sqlmodel import Field, Relationship
+
+from tests.sqlmodel import SQLModelTestCase
 
 
 class TestRelationshipToNonVersionedClass(SQLModelTestCase):
@@ -9,9 +11,7 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
         class User(self.Model, table=True):
             __tablename__ = 'user'
 
-            id: Union[int, None] = Field(
-                sa_type=sa.Integer, default=None, primary_key=True
-            )
+            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
             articles: list['Article'] = Relationship(back_populates='author')
 
@@ -19,13 +19,11 @@ class TestRelationshipToNonVersionedClass(SQLModelTestCase):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
             description: str = Field(sa_type=sa.UnicodeText, default='')
-            author_id: Union[int, None] = Field(
-                sa_type=sa.Integer, foreign_key='user.id'
-            )
+            author_id: int | None = Field(sa_type=sa.Integer, foreign_key='user.id')
             author: User = Relationship(back_populates='articles')
 
         self.Article = Article
@@ -61,10 +59,10 @@ class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
     def create_models(self):
         class ArticleTagLink(self.Model, table=True):
             __tablename__ = 'article_tag'
-            article_id: Union[int, None] = Field(
+            article_id: int | None = Field(
                 default=None, foreign_key='article.id', primary_key=True
             )
-            tag_id: Union[int, None] = Field(
+            tag_id: int | None = Field(
                 default=None, foreign_key='tag.id', primary_key=True
             )
 
@@ -72,7 +70,7 @@ class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             content: str = Field(default='')
             tags: list['Tag'] = Relationship(
@@ -82,7 +80,7 @@ class TestManyToManyRelationshipToNonVersionedClass(SQLModelTestCase):
         class Tag(self.Model, table=True):
             __tablename__ = 'tag'
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(max_length=255)
             articles: list[Article] = Relationship(
                 back_populates='tags', link_model=ArticleTagLink

--- a/tests/sqlmodel/relationships/test_one_to_one_relations.py
+++ b/tests/sqlmodel/relationships/test_one_to_one_relations.py
@@ -1,0 +1,85 @@
+from sqlmodel import Field, Relationship
+from tests import create_test_cases
+from tests.sqlmodel import SQLModelTestCase
+import sqlalchemy as sa
+
+
+class OneToOneRelationshipsTestCase(SQLModelTestCase):
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+            __versioned__ = {}
+
+            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            articles: list["Article"] = Relationship(back_populates="author")
+
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(sa_type=sa.UnicodeText, default="")
+            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
+            author: User = Relationship(back_populates="articles")
+
+        self.Article = Article
+        self.User = User
+
+    def test_single_insert(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+
+        assert article.versions[0].author
+
+    def test_multiple_relation_versions(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+        user.name = u'Someone else'
+        self.session.commit()
+
+        assert article.versions[0].author == user.versions[0]
+
+    def test_multiple_consecutive_inserts_and_removes(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+        user.name = u'Someone else'
+        self.session.commit()
+
+        article.name = u'Updated article'
+
+        article2 = self.Article(
+            name=u'Article 2',
+            content=""
+        )
+        self.session.add(article2)
+        article2.author = user
+        self.session.commit()
+
+        assert article2.versions[0].author == user.versions[1]
+
+    def test_replace(self):
+        article = self.Article(name=u'Some article', content=u'Some content')
+        user = self.User(name=u'Some user')
+        article.author = user
+        self.session.add(article)
+        self.session.commit()
+        other_user = self.User(name=u'Some other user')
+        article.author = other_user
+        self.session.commit()
+
+        assert article.versions[1].author == other_user.versions[0]
+
+
+create_test_cases(OneToOneRelationshipsTestCase)

--- a/tests/sqlmodel/relationships/test_one_to_one_relations.py
+++ b/tests/sqlmodel/relationships/test_one_to_one_relations.py
@@ -2,6 +2,7 @@ from sqlmodel import Field, Relationship
 from tests import create_test_cases
 from tests.sqlmodel import SQLModelTestCase
 import sqlalchemy as sa
+from typing import Union
 
 
 class OneToOneRelationshipsTestCase(SQLModelTestCase):
@@ -10,27 +11,31 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
             __tablename__ = 'user'
             __versioned__ = {}
 
-            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
+            id: Union[int, None] = Field(
+                sa_type=sa.Integer, default=None, primary_key=True
+            )
             name: str = Field(sa_type=sa.Unicode(255))
-            articles: list["Article"] = Relationship(back_populates="author")
+            articles: list['Article'] = Relationship(back_populates='author')
 
         class Article(self.Model, table=True):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
-            description: str = Field(sa_type=sa.UnicodeText, default="")
-            author_id: int | None = Field(sa_type=sa.Integer, foreign_key="user.id")
-            author: User = Relationship(back_populates="articles")
+            description: str = Field(sa_type=sa.UnicodeText, default='')
+            author_id: Union[int, None] = Field(
+                sa_type=sa.Integer, foreign_key='user.id'
+            )
+            author: User = Relationship(back_populates='articles')
 
         self.Article = Article
         self.User = User
 
     def test_single_insert(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
@@ -38,31 +43,28 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
         assert article.versions[0].author
 
     def test_multiple_relation_versions(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
-        user.name = u'Someone else'
+        user.name = 'Someone else'
         self.session.commit()
 
         assert article.versions[0].author == user.versions[0]
 
     def test_multiple_consecutive_inserts_and_removes(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
-        user.name = u'Someone else'
+        user.name = 'Someone else'
         self.session.commit()
 
-        article.name = u'Updated article'
+        article.name = 'Updated article'
 
-        article2 = self.Article(
-            name=u'Article 2',
-            content=""
-        )
+        article2 = self.Article(name='Article 2', content='')
         self.session.add(article2)
         article2.author = user
         self.session.commit()
@@ -70,12 +72,12 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
         assert article2.versions[0].author == user.versions[1]
 
     def test_replace(self):
-        article = self.Article(name=u'Some article', content=u'Some content')
-        user = self.User(name=u'Some user')
+        article = self.Article(name='Some article', content='Some content')
+        user = self.User(name='Some user')
         article.author = user
         self.session.add(article)
         self.session.commit()
-        other_user = self.User(name=u'Some other user')
+        other_user = self.User(name='Some other user')
         article.author = other_user
         self.session.commit()
 

--- a/tests/sqlmodel/relationships/test_one_to_one_relations.py
+++ b/tests/sqlmodel/relationships/test_one_to_one_relations.py
@@ -1,8 +1,10 @@
+from typing import Union
+
+import sqlalchemy as sa
 from sqlmodel import Field, Relationship
+
 from tests import create_test_cases
 from tests.sqlmodel import SQLModelTestCase
-import sqlalchemy as sa
-from typing import Union
 
 
 class OneToOneRelationshipsTestCase(SQLModelTestCase):
@@ -11,9 +13,7 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
             __tablename__ = 'user'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(
-                sa_type=sa.Integer, default=None, primary_key=True
-            )
+            id: int | None = Field(sa_type=sa.Integer, default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
             articles: list['Article'] = Relationship(back_populates='author')
 
@@ -21,13 +21,11 @@ class OneToOneRelationshipsTestCase(SQLModelTestCase):
             __tablename__ = 'article'
             __versioned__ = {}
 
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
             description: str = Field(sa_type=sa.UnicodeText, default='')
-            author_id: Union[int, None] = Field(
-                sa_type=sa.Integer, foreign_key='user.id'
-            )
+            author_id: int | None = Field(sa_type=sa.Integer, foreign_key='user.id')
             author: User = Relationship(back_populates='articles')
 
         self.Article = Article

--- a/tests/sqlmodel/test_delete.py
+++ b/tests/sqlmodel/test_delete.py
@@ -1,0 +1,26 @@
+import sqlalchemy as sa
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestDelete(SQLModelTestCase):
+    def _delete(self):
+        article = self.Article()
+        article.name = u'Some article'
+        article.content = u'Some content'
+        self.session.add(article)
+        self.session.commit()
+
+        self.session.delete(article)
+        self.session.commit()
+
+    def test_stores_operation_type(self):
+        self._delete()
+        versions = self.session.query(self.ArticleVersion).all()
+        assert versions[1].operation_type == 2
+
+    def test_creates_versions_on_delete(self):
+        self._delete()
+        versions = self.session.query(self.ArticleVersion).all()
+        assert len(versions) == 2
+        assert versions[1].name == u'Some article'
+        assert versions[1].content == u'Some content'

--- a/tests/sqlmodel/test_delete.py
+++ b/tests/sqlmodel/test_delete.py
@@ -5,8 +5,8 @@ from tests.sqlmodel import SQLModelTestCase
 class TestDelete(SQLModelTestCase):
     def _delete(self):
         article = self.Article()
-        article.name = u'Some article'
-        article.content = u'Some content'
+        article.name = 'Some article'
+        article.content = 'Some content'
         self.session.add(article)
         self.session.commit()
 
@@ -15,12 +15,16 @@ class TestDelete(SQLModelTestCase):
 
     def test_stores_operation_type(self):
         self._delete()
-        versions = self.session.query(self.ArticleVersion).all()
-        assert versions[1].operation_type == 2
+        versions = self.session.exec(
+            sa.select(self.ArticleVersion).order_by(
+                sa.asc(self.ArticleVersion.transaction_id)
+            )
+        ).all()
+        assert versions[1][0].operation_type == 2
 
     def test_creates_versions_on_delete(self):
         self._delete()
         versions = self.session.query(self.ArticleVersion).all()
         assert len(versions) == 2
-        assert versions[1].name == u'Some article'
-        assert versions[1].content == u'Some content'
+        assert versions[1].name == 'Some article'
+        assert versions[1].content == 'Some content'

--- a/tests/sqlmodel/test_delete.py
+++ b/tests/sqlmodel/test_delete.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+
 from tests.sqlmodel import SQLModelTestCase
 
 
@@ -24,7 +25,7 @@ class TestDelete(SQLModelTestCase):
 
     def test_creates_versions_on_delete(self):
         self._delete()
-        versions = self.session.query(self.ArticleVersion).all()
+        versions = self.session.scalars(sa.select(self.ArticleVersion)).all()
         assert len(versions) == 2
         assert versions[1].name == 'Some article'
         assert versions[1].content == 'Some content'

--- a/tests/sqlmodel/test_insert.py
+++ b/tests/sqlmodel/test_insert.py
@@ -1,0 +1,67 @@
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy_continuum import versioning_manager
+
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestInsertSQLModel(SQLModelTestCase):
+    def _insert(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+        return article
+
+    def test_insert_creates_version(self):
+        article = self._insert()
+        version = list(article.versions)[-1]
+        assert version.name == u'Some article'
+        assert version.content == u'Some content'
+        assert version.transaction.id == version.transaction_id
+
+    def test_stores_operation_type(self):
+        article = self._insert()
+        assert article.versions[0].operation_type == 0
+
+    def test_multiple_consecutive_flushes(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.flush()
+        article2 = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article2)
+        self.session.flush()
+        self.session.commit()
+        assert article.versions.count() == 1
+        assert article2.versions.count() == 1
+
+
+class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
+    def create_models(self):
+        self.Model = sqlmodel.SQLModel
+        class TextItem(self.Model, table=True):
+            __tablename__ = 'text_item'
+            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            name: str = sqlmodel.Field(sa.Unicode(255))
+
+        class Tag(self.Model, table=True):
+            __tablename__ = 'tag'
+            __versioned__ = {}
+            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            name: str = sqlmodel.Field(sa.Unicode(255))
+
+        self.TextItem = TextItem
+        self.Tag = Tag
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
+        self.Model.metadata.remove(self.TextItem.__table__)
+        self.Model.metadata.remove(self.Tag.__table__)
+
+    def test_does_not_create_transaction(self):
+        item = self.TextItem(name="test")
+        self.session.add(item)
+        self.session.commit()
+
+        assert self.session.query(
+            versioning_manager.transaction_cls
+        ).count() == 0

--- a/tests/sqlmodel/test_insert.py
+++ b/tests/sqlmodel/test_insert.py
@@ -1,13 +1,13 @@
 import sqlalchemy as sa
 import sqlmodel
 from sqlalchemy_continuum import versioning_manager
-
+from typing import Union
 from tests.sqlmodel import SQLModelTestCase
 
 
 class TestInsertSQLModel(SQLModelTestCase):
     def _insert(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         return article
@@ -15,8 +15,8 @@ class TestInsertSQLModel(SQLModelTestCase):
     def test_insert_creates_version(self):
         article = self._insert()
         version = list(article.versions)[-1]
-        assert version.name == u'Some article'
-        assert version.content == u'Some content'
+        assert version.name == 'Some article'
+        assert version.content == 'Some content'
         assert version.transaction.id == version.transaction_id
 
     def test_stores_operation_type(self):
@@ -24,10 +24,10 @@ class TestInsertSQLModel(SQLModelTestCase):
         assert article.versions[0].operation_type == 0
 
     def test_multiple_consecutive_flushes(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.flush()
-        article2 = self.Article(name=u"Some article", content=u"Some content")
+        article2 = self.Article(name='Some article', content='Some content')
         self.session.add(article2)
         self.session.flush()
         self.session.commit()
@@ -38,15 +38,16 @@ class TestInsertSQLModel(SQLModelTestCase):
 class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
     def create_models(self):
         self.Model = sqlmodel.SQLModel
+
         class TextItem(self.Model, table=True):
             __tablename__ = 'text_item'
-            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            id: Union[int, None] = sqlmodel.Field(default=None, primary_key=True)
             name: str = sqlmodel.Field(sa.Unicode(255))
 
         class Tag(self.Model, table=True):
             __tablename__ = 'tag'
             __versioned__ = {}
-            id: int | None = sqlmodel.Field(default=None, primary_key=True)
+            id: Union[int, None] = sqlmodel.Field(default=None, primary_key=True)
             name: str = sqlmodel.Field(sa.Unicode(255))
 
         self.TextItem = TextItem
@@ -58,10 +59,8 @@ class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
         self.Model.metadata.remove(self.Tag.__table__)
 
     def test_does_not_create_transaction(self):
-        item = self.TextItem(name="test")
+        item = self.TextItem(name='test')
         self.session.add(item)
         self.session.commit()
 
-        assert self.session.query(
-            versioning_manager.transaction_cls
-        ).count() == 0
+        assert self.session.query(versioning_manager.transaction_cls).count() == 0

--- a/tests/sqlmodel/test_insert.py
+++ b/tests/sqlmodel/test_insert.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 import sqlmodel
+
 from sqlalchemy_continuum import versioning_manager
-from typing import Union
 from tests.sqlmodel import SQLModelTestCase
 
 
@@ -41,13 +41,13 @@ class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
 
         class TextItem(self.Model, table=True):
             __tablename__ = 'text_item'
-            id: Union[int, None] = sqlmodel.Field(default=None, primary_key=True)
+            id: int | None = sqlmodel.Field(default=None, primary_key=True)
             name: str = sqlmodel.Field(sa.Unicode(255))
 
         class Tag(self.Model, table=True):
             __tablename__ = 'tag'
             __versioned__ = {}
-            id: Union[int, None] = sqlmodel.Field(default=None, primary_key=True)
+            id: int | None = sqlmodel.Field(default=None, primary_key=True)
             name: str = sqlmodel.Field(sa.Unicode(255))
 
         self.TextItem = TextItem
@@ -63,4 +63,11 @@ class TestInsertNonVersionedObjectSQLModel(SQLModelTestCase):
         self.session.add(item)
         self.session.commit()
 
-        assert self.session.query(versioning_manager.transaction_cls).count() == 0
+        assert (
+            self.session.scalar(
+                sa.select(sa.func.count()).select_from(
+                    versioning_manager.transaction_cls
+                )
+            )
+            == 0
+        )

--- a/tests/sqlmodel/test_revert.py
+++ b/tests/sqlmodel/test_revert.py
@@ -1,0 +1,166 @@
+from pytest import raises
+import sqlalchemy as sa
+from sqlmodel import Field, Relationship
+from sqlalchemy_continuum.reverter import Reverter, ReverterException
+
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestReverter(SQLModelTestCase):
+    def test_raises_exception_for_unknown_relations(self):
+        article = self.Article()
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+
+        self.session.commit()
+        version = article.versions[0]
+
+        with raises(ReverterException):
+            Reverter(version, relations=['unknown_relation'])
+
+
+class RevertTestCase(SQLModelTestCase):
+    def add_article(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+        return article
+
+    def test_simple_revert(self):
+        article = self.add_article()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        self.session.commit()
+        self.session.refresh(article)
+        article.versions[0].revert()
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+
+    def test_revert_deleted_model(self):
+        article = self.add_article()
+        old_article_id = article.id
+        version = article.versions[0]
+        self.session.delete(article)
+        self.session.commit()
+        version.revert()
+        assert article.id == old_article_id
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+
+    def test_revert_deletion(self):
+        article = self.add_article()
+        old_article_id = article.id
+        version = article.versions[0]
+        self.session.delete(article)
+        self.session.commit()
+        version.revert()
+        self.session.commit()
+        assert self.session.query(self.Article).count() == 1
+        article = self.session.query(self.Article).get(old_article_id)
+
+        assert version.next.next
+
+        version.next.revert()
+        self.session.commit()
+        assert not self.session.query(self.Article).get(old_article_id)
+
+    def test_revert_version_with_one_to_many_relation(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        article.tags.append(self.Tag(name=u'some tag'))
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        article.tags = []
+        self.session.commit()
+        self.session.refresh(article)
+        assert article.tags == []
+        assert len(article.versions[0].tags) == 1
+        assert article.versions[0].tags[0].article
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+        assert len(article.tags) == 1
+        assert article.tags[0].name == u'some tag'
+
+    def test_with_one_to_many_relation_delete_newly_added(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        article.tags.append(self.Tag(name=u'some tag'))
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+        article.tags.append(self.Tag(name=u'some other tag'))
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        assert len(article.tags) == 2
+        assert len(article.versions[0].tags) == 1
+        assert article.versions[0].tags[0].article
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+
+        assert article.name == u'Some article'
+        assert article.content == u'Some content'
+        assert len(article.tags) == 1
+        assert article.tags[0].name == u'some tag'
+
+    def test_with_one_to_many_relation_resurrect_deleted(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        tag = self.Tag(name=u'some other tag')
+        article.tags.append(self.Tag(name=u'some tag'))
+        article.tags.append(tag)
+        self.session.add(article)
+        self.session.commit()
+        article.name = u'Updated name'
+        article.tags.remove(tag)
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        assert len(article.tags) == 1
+        assert len(article.versions[0].tags) == 2
+        article.versions[0].revert(relations=['tags'])
+        self.session.commit()
+        assert len(article.tags) == 2
+        assert article.tags[0].name == u'some tag'
+
+
+class TestRevertWithDefaultVersioningStrategy(RevertTestCase):
+    pass
+
+
+class TestRevertWithValidityVersioningStrategy(RevertTestCase):
+    versioning_strategy = 'validity'
+
+
+class TestRevertWithCustomTransactionColumn(RevertTestCase):
+    transaction_column_name = 'tx_id'
+
+
+class TestRevertWithColumnExclusion(RevertTestCase):
+    def create_models(self):
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {
+                'exclude': ['description']
+            }
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            content: str = Field(sa_type=sa.UnicodeText)
+            description: str = Field(sa_type=sa.UnicodeText, default=None, nullable=True)
+            tags: list["Tag"] = Relationship(back_populates="article")
+
+        class Tag(self.Model, table=True):
+            __tablename__ = 'tag'
+            __versioned__ = {}
+
+            id: int = Field(sa_type=sa.Integer, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255))
+            article_id: int | None = Field(default=None, foreign_key="article.id")
+            article: Article = Relationship(back_populates="tags")
+
+        self.Article = Article
+        self.Tag = Tag

--- a/tests/sqlmodel/test_revert.py
+++ b/tests/sqlmodel/test_revert.py
@@ -4,12 +4,13 @@ from sqlmodel import Field, Relationship
 from sqlalchemy_continuum.reverter import Reverter, ReverterException
 
 from tests.sqlmodel import SQLModelTestCase
+from typing import Union
 
 
 class TestReverter(SQLModelTestCase):
     def test_raises_exception_for_unknown_relations(self):
         article = self.Article()
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
 
         self.session.commit()
@@ -21,20 +22,20 @@ class TestReverter(SQLModelTestCase):
 
 class RevertTestCase(SQLModelTestCase):
     def add_article(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         return article
 
     def test_simple_revert(self):
         article = self.add_article()
-        article.name = u'Updated name'
-        article.content = u'Updated content'
+        article.name = 'Updated name'
+        article.content = 'Updated content'
         self.session.commit()
         self.session.refresh(article)
         article.versions[0].revert()
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
 
     def test_revert_deleted_model(self):
         article = self.add_article()
@@ -44,8 +45,8 @@ class RevertTestCase(SQLModelTestCase):
         self.session.commit()
         version.revert()
         assert article.id == old_article_id
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
 
     def test_revert_deletion(self):
         article = self.add_article()
@@ -65,12 +66,12 @@ class RevertTestCase(SQLModelTestCase):
         assert not self.session.query(self.Article).get(old_article_id)
 
     def test_revert_version_with_one_to_many_relation(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
-        article.tags.append(self.Tag(name=u'some tag'))
+        article = self.Article(name='Some article', content='Some content')
+        article.tags.append(self.Tag(name='some tag'))
         self.session.add(article)
         self.session.commit()
-        article.name = u'Updated name'
-        article.content = u'Updated content'
+        article.name = 'Updated name'
+        article.content = 'Updated content'
         article.tags = []
         self.session.commit()
         self.session.refresh(article)
@@ -80,19 +81,19 @@ class RevertTestCase(SQLModelTestCase):
         article.versions[0].revert(relations=['tags'])
         self.session.commit()
 
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
         assert len(article.tags) == 1
-        assert article.tags[0].name == u'some tag'
+        assert article.tags[0].name == 'some tag'
 
     def test_with_one_to_many_relation_delete_newly_added(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
-        article.tags.append(self.Tag(name=u'some tag'))
+        article = self.Article(name='Some article', content='Some content')
+        article.tags.append(self.Tag(name='some tag'))
         self.session.add(article)
         self.session.commit()
-        article.name = u'Updated name'
-        article.content = u'Updated content'
-        article.tags.append(self.Tag(name=u'some other tag'))
+        article.name = 'Updated name'
+        article.content = 'Updated content'
+        article.tags.append(self.Tag(name='some other tag'))
         self.session.add(article)
         self.session.commit()
         self.session.refresh(article)
@@ -102,19 +103,19 @@ class RevertTestCase(SQLModelTestCase):
         article.versions[0].revert(relations=['tags'])
         self.session.commit()
 
-        assert article.name == u'Some article'
-        assert article.content == u'Some content'
+        assert article.name == 'Some article'
+        assert article.content == 'Some content'
         assert len(article.tags) == 1
-        assert article.tags[0].name == u'some tag'
+        assert article.tags[0].name == 'some tag'
 
     def test_with_one_to_many_relation_resurrect_deleted(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
-        tag = self.Tag(name=u'some other tag')
-        article.tags.append(self.Tag(name=u'some tag'))
+        article = self.Article(name='Some article', content='Some content')
+        tag = self.Tag(name='some other tag')
+        article.tags.append(self.Tag(name='some tag'))
         article.tags.append(tag)
         self.session.add(article)
         self.session.commit()
-        article.name = u'Updated name'
+        article.name = 'Updated name'
         article.tags.remove(tag)
         self.session.add(article)
         self.session.commit()
@@ -124,7 +125,7 @@ class RevertTestCase(SQLModelTestCase):
         article.versions[0].revert(relations=['tags'])
         self.session.commit()
         assert len(article.tags) == 2
-        assert article.tags[0].name == u'some tag'
+        assert article.tags[0].name == 'some tag'
 
 
 class TestRevertWithDefaultVersioningStrategy(RevertTestCase):
@@ -143,15 +144,15 @@ class TestRevertWithColumnExclusion(RevertTestCase):
     def create_models(self):
         class Article(self.Model, table=True):
             __tablename__ = 'article'
-            __versioned__ = {
-                'exclude': ['description']
-            }
+            __versioned__ = {'exclude': ['description']}
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             content: str = Field(sa_type=sa.UnicodeText)
-            description: str = Field(sa_type=sa.UnicodeText, default=None, nullable=True)
-            tags: list["Tag"] = Relationship(back_populates="article")
+            description: str = Field(
+                sa_type=sa.UnicodeText, default=None, nullable=True
+            )
+            tags: list['Tag'] = Relationship(back_populates='article')
 
         class Tag(self.Model, table=True):
             __tablename__ = 'tag'
@@ -159,8 +160,8 @@ class TestRevertWithColumnExclusion(RevertTestCase):
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
-            article_id: int | None = Field(default=None, foreign_key="article.id")
-            article: Article = Relationship(back_populates="tags")
+            article_id: Union[int, None] = Field(default=None, foreign_key='article.id')
+            article: Article = Relationship(back_populates='tags')
 
         self.Article = Article
         self.Tag = Tag

--- a/tests/sqlmodel/test_revert.py
+++ b/tests/sqlmodel/test_revert.py
@@ -1,10 +1,9 @@
-from pytest import raises
 import sqlalchemy as sa
+from pytest import raises
 from sqlmodel import Field, Relationship
-from sqlalchemy_continuum.reverter import Reverter, ReverterException
 
+from sqlalchemy_continuum.reverter import Reverter, ReverterException
 from tests.sqlmodel import SQLModelTestCase
-from typing import Union
 
 
 class TestReverter(SQLModelTestCase):
@@ -56,14 +55,18 @@ class RevertTestCase(SQLModelTestCase):
         self.session.commit()
         version.revert()
         self.session.commit()
-        assert self.session.query(self.Article).count() == 1
-        article = self.session.query(self.Article).get(old_article_id)
+        assert (
+            self.session.scalar(sa.select(sa.func.count()).select_from(self.Article))
+            == 1
+        )
+
+        article = self.session.get(self.Article, old_article_id)
 
         assert version.next.next
 
         version.next.revert()
         self.session.commit()
-        assert not self.session.query(self.Article).get(old_article_id)
+        assert not self.session.get(self.Article, old_article_id)
 
     def test_revert_version_with_one_to_many_relation(self):
         article = self.Article(name='Some article', content='Some content')
@@ -160,7 +163,7 @@ class TestRevertWithColumnExclusion(RevertTestCase):
 
             id: int = Field(sa_type=sa.Integer, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255))
-            article_id: Union[int, None] = Field(default=None, foreign_key='article.id')
+            article_id: int | None = Field(default=None, foreign_key='article.id')
             article: Article = Relationship(back_populates='tags')
 
         self.Article = Article

--- a/tests/sqlmodel/test_transaction.py
+++ b/tests/sqlmodel/test_transaction.py
@@ -1,0 +1,89 @@
+import sqlalchemy as sa
+from sqlmodel import AutoString, Field
+from sqlalchemy_continuum import versioning_manager
+from tests.sqlmodel import SQLModelTestCase
+from sqlalchemy_continuum.plugins import TransactionMetaPlugin
+
+
+
+class TestTransaction(SQLModelTestCase):
+    def setup_method(self, method):
+        SQLModelTestCase.setup_method(self, method)
+        self.article = self.Article(name= u'Some article', content=u'Some content')
+        self.article.tags.append(self.Tag(name=u'Some tag'))
+        self.session.add(self.article)
+        self.session.commit()
+
+    def test_relationships(self):
+        assert self.article.versions[0].transaction
+
+    def test_only_saves_transaction_if_actual_modifications(self):
+        self.article.name = u'Some article'
+        self.session.commit()
+        self.article.name = u'Some article'
+        self.session.commit()
+        assert self.session.query(
+            versioning_manager.transaction_cls
+        ).count() == 1
+
+    def test_repr(self):
+        transaction = self.session.query(
+            versioning_manager.transaction_cls
+        ).first()
+        assert (
+            '<Transaction id=%d, issued_at=%r>' % (
+                transaction.id,
+                transaction.issued_at
+            ) ==
+            repr(transaction)
+        )
+
+    def test_changed_entities(self):
+        article_v0 = self.article.versions[0]
+        transaction = article_v0.transaction
+        assert transaction.changed_entities == {
+            self.ArticleVersion: [article_v0],
+            self.TagVersion: [self.article.tags[0].versions[0]],
+        }
+
+
+# Check that the tests pass without TransactionChangesPlugin
+class TestTransactionWithoutChangesPlugin(TestTransaction):
+    plugins = [TransactionMetaPlugin()]
+
+
+class TestAssigningUserClass(SQLModelTestCase):
+    user_cls = 'User'
+
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+            __versioned__ = {}
+            id: str | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+
+        self.User = User
+
+    def test_copies_primary_key_type_from_user_class(self):
+        attr = versioning_manager.transaction_cls.user_id
+        assert isinstance(attr.property.columns[0].type, AutoString)
+
+
+class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
+    user_cls = 'User'
+
+    def create_models(self):
+        class User(self.Model, table=True):
+            __tablename__ = 'user'
+            __versioned__ = {}
+            __table_args__ = {'schema': 'other'}
+
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+
+        self.User = User
+
+    def test_can_build_transaction_model(self):
+        # If create_models didn't crash this should be good
+        pass
+

--- a/tests/sqlmodel/test_transaction.py
+++ b/tests/sqlmodel/test_transaction.py
@@ -3,14 +3,14 @@ from sqlmodel import AutoString, Field
 from sqlalchemy_continuum import versioning_manager
 from tests.sqlmodel import SQLModelTestCase
 from sqlalchemy_continuum.plugins import TransactionMetaPlugin
-
+from typing import Union
 
 
 class TestTransaction(SQLModelTestCase):
     def setup_method(self, method):
         SQLModelTestCase.setup_method(self, method)
-        self.article = self.Article(name= u'Some article', content=u'Some content')
-        self.article.tags.append(self.Tag(name=u'Some tag'))
+        self.article = self.Article(name='Some article', content='Some content')
+        self.article.tags.append(self.Tag(name='Some tag'))
         self.session.add(self.article)
         self.session.commit()
 
@@ -18,25 +18,18 @@ class TestTransaction(SQLModelTestCase):
         assert self.article.versions[0].transaction
 
     def test_only_saves_transaction_if_actual_modifications(self):
-        self.article.name = u'Some article'
+        self.article.name = 'Some article'
         self.session.commit()
-        self.article.name = u'Some article'
+        self.article.name = 'Some article'
         self.session.commit()
-        assert self.session.query(
-            versioning_manager.transaction_cls
-        ).count() == 1
+        assert self.session.query(versioning_manager.transaction_cls).count() == 1
 
     def test_repr(self):
-        transaction = self.session.query(
-            versioning_manager.transaction_cls
-        ).first()
-        assert (
-            '<Transaction id=%d, issued_at=%r>' % (
-                transaction.id,
-                transaction.issued_at
-            ) ==
-            repr(transaction)
-        )
+        transaction = self.session.query(versioning_manager.transaction_cls).first()
+        assert '<Transaction id=%d, issued_at=%r>' % (
+            transaction.id,
+            transaction.issued_at,
+        ) == repr(transaction)
 
     def test_changed_entities(self):
         article_v0 = self.article.versions[0]
@@ -59,7 +52,7 @@ class TestAssigningUserClass(SQLModelTestCase):
         class User(self.Model, table=True):
             __tablename__ = 'user'
             __versioned__ = {}
-            id: str | None = Field(default=None, primary_key=True)
+            id: Union[str, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
 
         self.User = User
@@ -78,7 +71,7 @@ class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
             __versioned__ = {}
             __table_args__ = {'schema': 'other'}
 
-            id: int | None = Field(default=None, primary_key=True)
+            id: Union[str, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
 
         self.User = User
@@ -86,4 +79,3 @@ class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
     def test_can_build_transaction_model(self):
         # If create_models didn't crash this should be good
         pass
-

--- a/tests/sqlmodel/test_transaction.py
+++ b/tests/sqlmodel/test_transaction.py
@@ -1,9 +1,9 @@
 import sqlalchemy as sa
 from sqlmodel import AutoString, Field
+
 from sqlalchemy_continuum import versioning_manager
-from tests.sqlmodel import SQLModelTestCase
 from sqlalchemy_continuum.plugins import TransactionMetaPlugin
-from typing import Union
+from tests.sqlmodel import SQLModelTestCase
 
 
 class TestTransaction(SQLModelTestCase):
@@ -22,14 +22,23 @@ class TestTransaction(SQLModelTestCase):
         self.session.commit()
         self.article.name = 'Some article'
         self.session.commit()
-        assert self.session.query(versioning_manager.transaction_cls).count() == 1
+        assert (
+            self.session.scalar(
+                sa.select(sa.func.count()).select_from(
+                    versioning_manager.transaction_cls
+                )
+            )
+            == 1
+        )
 
     def test_repr(self):
-        transaction = self.session.query(versioning_manager.transaction_cls).first()
-        assert '<Transaction id=%d, issued_at=%r>' % (
-            transaction.id,
-            transaction.issued_at,
-        ) == repr(transaction)
+        transaction = self.session.scalars(
+            sa.select(versioning_manager.transaction_cls)
+        ).first()
+        assert (
+            f'<Transaction id={transaction.id:d}, issued_at={transaction.issued_at!r}>'
+            == repr(transaction)
+        )
 
     def test_changed_entities(self):
         article_v0 = self.article.versions[0]
@@ -52,7 +61,7 @@ class TestAssigningUserClass(SQLModelTestCase):
         class User(self.Model, table=True):
             __tablename__ = 'user'
             __versioned__ = {}
-            id: Union[str, None] = Field(default=None, primary_key=True)
+            id: str | None = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
 
         self.User = User
@@ -71,7 +80,7 @@ class TestAssigningUserClassInOtherSchema(SQLModelTestCase):
             __versioned__ = {}
             __table_args__ = {'schema': 'other'}
 
-            id: Union[str, None] = Field(default=None, primary_key=True)
+            id: str | None = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
 
         self.User = User

--- a/tests/sqlmodel/test_update.py
+++ b/tests/sqlmodel/test_update.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestUpdateSQLModel(SQLModelTestCase):
+    def test_creates_versions_on_update(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = u'Updated name'
+        article.content = u'Updated content'
+
+        self.session.commit()
+        self.session.refresh(article)
+        version = list(article.versions)[-1]
+        assert version.name == u'Updated name'
+        assert version.content == u'Updated content'
+        assert version.transaction.id == version.transaction_id
+
+    def test_partial_update(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.content = u'Updated content'
+
+        self.session.commit()
+        self.session.refresh(article)
+        version = list(article.versions)[-1]
+        assert version.name == u'Some article'
+        assert version.content == u'Updated content'
+        assert version.transaction.id == version.transaction_id
+
+    def test_update_with_same_values(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+        self.session.refresh(article)
+        article.name = u'Some article'
+
+        self.session.commit()
+        assert article.versions.count() == 1
+
+    def test_stores_operation_type(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = u'Some other article'
+
+        self.session.commit()
+        assert list(article.versions)[-1].operation_type == 1
+
+    def test_multiple_updates_within_same_transaction(self):
+        article = self.Article(name=u"Some article", content=u"Some content")
+        self.session.add(article)
+        self.session.commit()
+
+        article.content = u'Updated content'
+        self.session.flush()
+        article.content = u'Updated content 2'
+        self.session.commit()
+        assert article.versions.count() == 2
+        version = list(article.versions)[-1]
+        assert version.name == u'Some article'
+        assert version.content == u'Updated content 2'
+
+
+class TestUpdateWithDefaultValuesSQLModel(SQLModelTestCase):
+    def create_models(self):
+        self.Model = SQLModel
+        class Article(self.Model, table=True):
+            __tablename__ = 'article'
+            __versioned__ = {
+            }
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(sa_type=sa.Unicode(255), nullable=False)
+            updated_at: datetime = Field(sa_type=sa.DateTime, sa_column_kwargs={"server_default": sa.func.now()})
+            is_editable: bool = Field()
+
+        self.Article = Article
+
+    def test_update_with_default_values(self):
+        article = self.Article(name=u"Some article", is_editable=False)
+        self.session.add(article)
+        self.session.commit()
+
+        article.is_editable = True
+        self.session.commit()
+        article = list(article.versions)[-1]
+        assert article.name == u'Some article'

--- a/tests/sqlmodel/test_update.py
+++ b/tests/sqlmodel/test_update.py
@@ -3,93 +3,96 @@ from datetime import datetime
 import sqlalchemy as sa
 from sqlmodel import Field, SQLModel
 from tests.sqlmodel import SQLModelTestCase
+from typing import Union
 
 
 class TestUpdateSQLModel(SQLModelTestCase):
     def test_creates_versions_on_update(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.name = u'Updated name'
-        article.content = u'Updated content'
+        article.name = 'Updated name'
+        article.content = 'Updated content'
 
         self.session.commit()
         self.session.refresh(article)
         version = list(article.versions)[-1]
-        assert version.name == u'Updated name'
-        assert version.content == u'Updated content'
+        assert version.name == 'Updated name'
+        assert version.content == 'Updated content'
         assert version.transaction.id == version.transaction_id
 
     def test_partial_update(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.content = u'Updated content'
+        article.content = 'Updated content'
 
         self.session.commit()
         self.session.refresh(article)
         version = list(article.versions)[-1]
-        assert version.name == u'Some article'
-        assert version.content == u'Updated content'
+        assert version.name == 'Some article'
+        assert version.content == 'Updated content'
         assert version.transaction.id == version.transaction_id
 
     def test_update_with_same_values(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
         self.session.refresh(article)
-        article.name = u'Some article'
+        article.name = 'Some article'
 
         self.session.commit()
         assert article.versions.count() == 1
 
     def test_stores_operation_type(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.name = u'Some other article'
+        article.name = 'Some other article'
 
         self.session.commit()
         assert list(article.versions)[-1].operation_type == 1
 
     def test_multiple_updates_within_same_transaction(self):
-        article = self.Article(name=u"Some article", content=u"Some content")
+        article = self.Article(name='Some article', content='Some content')
         self.session.add(article)
         self.session.commit()
 
-        article.content = u'Updated content'
+        article.content = 'Updated content'
         self.session.flush()
-        article.content = u'Updated content 2'
+        article.content = 'Updated content 2'
         self.session.commit()
         assert article.versions.count() == 2
         version = list(article.versions)[-1]
-        assert version.name == u'Some article'
-        assert version.content == u'Updated content 2'
+        assert version.name == 'Some article'
+        assert version.content == 'Updated content 2'
 
 
 class TestUpdateWithDefaultValuesSQLModel(SQLModelTestCase):
     def create_models(self):
         self.Model = SQLModel
+
         class Article(self.Model, table=True):
             __tablename__ = 'article'
-            __versioned__ = {
-            }
-            id: int | None = Field(default=None, primary_key=True)
+            __versioned__ = {}
+            id: Union[int, None] = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
-            updated_at: datetime = Field(sa_type=sa.DateTime, sa_column_kwargs={"server_default": sa.func.now()})
+            updated_at: datetime = Field(
+                sa_type=sa.DateTime, sa_column_kwargs={'server_default': sa.func.now()}
+            )
             is_editable: bool = Field()
 
         self.Article = Article
 
     def test_update_with_default_values(self):
-        article = self.Article(name=u"Some article", is_editable=False)
+        article = self.Article(name='Some article', is_editable=False)
         self.session.add(article)
         self.session.commit()
 
         article.is_editable = True
         self.session.commit()
         article = list(article.versions)[-1]
-        assert article.name == u'Some article'
+        assert article.name == 'Some article'

--- a/tests/sqlmodel/test_update.py
+++ b/tests/sqlmodel/test_update.py
@@ -1,9 +1,10 @@
 from datetime import datetime
+from typing import Union
 
 import sqlalchemy as sa
 from sqlmodel import Field, SQLModel
+
 from tests.sqlmodel import SQLModelTestCase
-from typing import Union
 
 
 class TestUpdateSQLModel(SQLModelTestCase):
@@ -78,7 +79,7 @@ class TestUpdateWithDefaultValuesSQLModel(SQLModelTestCase):
         class Article(self.Model, table=True):
             __tablename__ = 'article'
             __versioned__ = {}
-            id: Union[int, None] = Field(default=None, primary_key=True)
+            id: int | None = Field(default=None, primary_key=True)
             name: str = Field(sa_type=sa.Unicode(255), nullable=False)
             updated_at: datetime = Field(
                 sa_type=sa.DateTime, sa_column_kwargs={'server_default': sa.func.now()}

--- a/tests/sqlmodel/test_versions.py
+++ b/tests/sqlmodel/test_versions.py
@@ -1,0 +1,24 @@
+from tests.sqlmodel import SQLModelTestCase
+
+
+class TestVersions(SQLModelTestCase):
+    def test_versions_ordered_by_transaction_id(self):
+        names = [
+            u'Some article',
+            u'Update 1 article',
+            u'Update 2 article',
+            u'Update 3 article',
+        ]
+
+        article = self.Article(name=names[0], content="")
+        self.session.add(article)
+        self.session.commit()
+        article.name = names[1]
+        self.session.commit()
+        article.name = names[2]
+        self.session.commit()
+        article.name = names[3]
+        self.session.commit()
+
+        for index, name in enumerate(names):
+            assert article.versions[index].name == name

--- a/tests/sqlmodel/test_versions.py
+++ b/tests/sqlmodel/test_versions.py
@@ -4,13 +4,13 @@ from tests.sqlmodel import SQLModelTestCase
 class TestVersions(SQLModelTestCase):
     def test_versions_ordered_by_transaction_id(self):
         names = [
-            u'Some article',
-            u'Update 1 article',
-            u'Update 2 article',
-            u'Update 3 article',
+            'Some article',
+            'Update 1 article',
+            'Update 2 article',
+            'Update 3 article',
         ]
 
-        article = self.Article(name=names[0], content="")
+        article = self.Article(name=names[0], content='')
         self.session.add(article)
         self.session.commit()
         article.name = names[1]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@ labels =
 
 [testenv]
 commands = pytest
-dependency_groups = test
+dependency_groups =
+    test
+    sqlalchemy2: test-sqlmodel
 passenv =
     DB
     DATABASE_URL

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,63 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
 
 [[package]]
 name = "blinker"
@@ -21,12 +78,108 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a", size = 322240, upload-time = "2026-07-07T14:32:36.236Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616", size = 216475, upload-time = "2026-07-07T14:32:38.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/33/6c99c1b3e6b8bf730e1bc809b9a2608f224145069114c479a2e9e1494346/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209", size = 238670, upload-time = "2026-07-07T14:32:39.658Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f4/ffbb83546e1f198ecc70ecd372b65cf2b50f9068b380abd67640f17a8e18/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99", size = 233476, upload-time = "2026-07-07T14:32:41.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8", size = 223817, upload-time = "2026-07-07T14:32:42.592Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/a276bb2e66243072a3fd06fdcab9cbb61a305b02143d70d2bda21d888fa8/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b", size = 207974, upload-time = "2026-07-07T14:32:44.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/be/7ee4453d7e88dfbc4104ccd34900b9f2c7c17dac22881865fe0e82424a25/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2", size = 221655, upload-time = "2026-07-07T14:32:45.64Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/181c652953eb5276d198f375b1dd641047392050098100a3a02d6534f657/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9", size = 219229, upload-time = "2026-07-07T14:32:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/aaf6da33fc9f4691cda8f7efbc9f69179d3d39ec8a4799baf273ee1d8db0/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15", size = 209704, upload-time = "2026-07-07T14:32:48.855Z" },
+    { url = "https://files.pythonhosted.org/packages/63/01/f2fb3bd3a73be48b173ee0c6aa8d2497af97d5663a8c4c4b491de4c62f7a/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d", size = 226243, upload-time = "2026-07-07T14:32:50.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/02/c57a22739fe05246b0b5783b3bfb6afaac4eebb46f3ececdfb2f048f780e/charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381", size = 150935, upload-time = "2026-07-07T14:32:51.676Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee", size = 162314, upload-time = "2026-07-07T14:32:53.193Z" },
+    { url = "https://files.pythonhosted.org/packages/01/da/a44bd7a13d426e69e4894557106cd58669097bfad4a8681123b618fbfc5d/charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419", size = 153075, upload-time = "2026-07-07T14:32:54.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -66,6 +219,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -130,6 +308,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/53/b0a9fcc1b1297f51e68b69ed3b7c3c40d8c45be1391d77ae198712914392/flask_sqlalchemy-3.1.1.tar.gz", hash = "sha256:e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312", size = 81899, upload-time = "2023-09-11T21:42:36.147Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl", hash = "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0", size = 25125, upload-time = "2023-09-11T21:42:34.514Z" },
+]
+
+[[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
 ]
 
 [[package]]
@@ -230,6 +426,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
@@ -524,6 +738,137 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -687,6 +1032,30 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
@@ -718,6 +1087,185 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "8.1.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
@@ -784,6 +1332,17 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "ruff" },
+    { name = "tox" },
+]
+docs = [
+    { name = "furo" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 flask = [
     { name = "flask" },
 ]
@@ -792,6 +1351,19 @@ flask-login = [
 ]
 flask-sqlalchemy = [
     { name = "flask-sqlalchemy" },
+]
+sqlmodel = [
+    { name = "sqlmodel" },
+]
+test = [
+    { name = "flask" },
+    { name = "flask-login" },
+    { name = "flask-sqlalchemy" },
+    { name = "packaging" },
+    { name = "psycopg2" },
+    { name = "pymysql" },
+    { name = "pytest" },
+    { name = "sqlmodel" },
 ]
 
 [package.dev-dependencies]
@@ -828,12 +1400,26 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "flask", marker = "extra == 'flask'", specifier = ">=2.0" },
-    { name = "flask-login", marker = "extra == 'flask-login'", specifier = ">=0.6" },
-    { name = "flask-sqlalchemy", marker = "extra == 'flask-sqlalchemy'", specifier = ">=3.0" },
+    { name = "flask", marker = "extra == 'flask'", specifier = ">=0.9" },
+    { name = "flask", marker = "extra == 'test'", specifier = ">=0.9" },
+    { name = "flask-login", marker = "extra == 'flask-login'", specifier = ">=0.2.9" },
+    { name = "flask-login", marker = "extra == 'test'", specifier = ">=0.2.9" },
+    { name = "flask-sqlalchemy", marker = "extra == 'flask-sqlalchemy'", specifier = ">=1.0" },
+    { name = "flask-sqlalchemy", marker = "extra == 'test'", specifier = ">=1.0" },
+    { name = "furo", marker = "extra == 'docs'", specifier = ">=2021.11.0" },
+    { name = "packaging", marker = "extra == 'test'" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "psycopg2", marker = "extra == 'test'", specifier = ">=2.4.6" },
+    { name = "pymysql", marker = "extra == 'test'", specifier = ">=0.8.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=2.3.5" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=4.0.0" },
     { name = "sqlalchemy", specifier = ">=1.4.53,<2.1" },
+    { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.24" },
+    { name = "sqlmodel", marker = "extra == 'test'", specifier = ">=0.0.24" },
+    { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["flask", "flask-login", "flask-sqlalchemy"]
+provides-extras = ["test", "flask", "flask-login", "flask-sqlalchemy", "sqlmodel", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -863,6 +1449,20 @@ test = [
     { name = "psycopg2", specifier = ">=2.9" },
     { name = "pymysql", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=7.0" },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.39"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ee/22a0559283c3cf6048678e787ed5d4959dcd00dedd8ba4567eeae684eeb1/sqlmodel-0.0.39.tar.gz", hash = "sha256:23d8e50a8d8ee936032ed79c55023a5d618dd6bc3c510bbf4909d1a7a605a570", size = 91057, upload-time = "2026-06-25T13:01:38.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/7d/b9813a582d4eb310be35e1fc7dfaae71207d7b62e9e53be314ebd251b53b/sqlmodel-0.0.39-py3-none-any.whl", hash = "sha256:90ebe92ce5cc11d7fff8dc7cb594790a102333c8fe7c14865254f6fc5c939795", size = 29680, upload-time = "2026-06-25T13:01:37.494Z" },
 ]
 
 [[package]]
@@ -958,6 +1558,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -973,6 +973,8 @@ test = [
     { name = "psycopg2" },
     { name = "pymysql" },
     { name = "pytest" },
+]
+test-sqlmodel = [
     { name = "sqlmodel" },
 ]
 
@@ -1015,8 +1017,8 @@ test = [
     { name = "psycopg2", specifier = ">=2.9" },
     { name = "pymysql", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=7.0" },
-    { name = "sqlmodel", specifier = ">=0.0.24" },
 ]
+test-sqlmodel = [{ name = "sqlmodel", specifier = ">=0.0.24" }]
 
 [[package]]
 name = "sqlmodel"

--- a/uv.lock
+++ b/uv.lock
@@ -8,55 +8,12 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "accessible-pygments"
-version = "0.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
-]
-
-[[package]]
-name = "alabaster"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "babel"
-version = "2.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "beautifulsoup4"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -78,108 +35,12 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2026.6.17"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
-]
-
-[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a", size = 322240, upload-time = "2026-07-07T14:32:36.236Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616", size = 216475, upload-time = "2026-07-07T14:32:38.142Z" },
-    { url = "https://files.pythonhosted.org/packages/80/33/6c99c1b3e6b8bf730e1bc809b9a2608f224145069114c479a2e9e1494346/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209", size = 238670, upload-time = "2026-07-07T14:32:39.658Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f4/ffbb83546e1f198ecc70ecd372b65cf2b50f9068b380abd67640f17a8e18/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99", size = 233476, upload-time = "2026-07-07T14:32:41.155Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8", size = 223817, upload-time = "2026-07-07T14:32:42.592Z" },
-    { url = "https://files.pythonhosted.org/packages/36/31/a276bb2e66243072a3fd06fdcab9cbb61a305b02143d70d2bda21d888fa8/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b", size = 207974, upload-time = "2026-07-07T14:32:44.258Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/be/7ee4453d7e88dfbc4104ccd34900b9f2c7c17dac22881865fe0e82424a25/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2", size = 221655, upload-time = "2026-07-07T14:32:45.64Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/181c652953eb5276d198f375b1dd641047392050098100a3a02d6534f657/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9", size = 219229, upload-time = "2026-07-07T14:32:47.376Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e7/aaf6da33fc9f4691cda8f7efbc9f69179d3d39ec8a4799baf273ee1d8db0/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15", size = 209704, upload-time = "2026-07-07T14:32:48.855Z" },
-    { url = "https://files.pythonhosted.org/packages/63/01/f2fb3bd3a73be48b173ee0c6aa8d2497af97d5663a8c4c4b491de4c62f7a/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d", size = 226243, upload-time = "2026-07-07T14:32:50.239Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/02/c57a22739fe05246b0b5783b3bfb6afaac4eebb46f3ececdfb2f048f780e/charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381", size = 150935, upload-time = "2026-07-07T14:32:51.676Z" },
-    { url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee", size = 162314, upload-time = "2026-07-07T14:32:53.193Z" },
-    { url = "https://files.pythonhosted.org/packages/01/da/a44bd7a13d426e69e4894557106cd58669097bfad4a8681123b618fbfc5d/charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419", size = 153075, upload-time = "2026-07-07T14:32:54.554Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
-    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
-    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
-    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
-    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
-    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
-    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
-    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
-    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
-    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
-    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
-    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
-    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
-    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
-    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
-    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
-    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
-    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -222,36 +83,11 @@ wheels = [
 ]
 
 [[package]]
-name = "docutils"
-version = "0.21.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
-]
-
-[[package]]
-name = "docutils"
-version = "0.22.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -308,24 +144,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/53/b0a9fcc1b1297f51e68b69ed3b7c3c40d8c45be1391d77ae198712914392/flask_sqlalchemy-3.1.1.tar.gz", hash = "sha256:e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312", size = 81899, upload-time = "2023-09-11T21:42:36.147Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl", hash = "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0", size = 25125, upload-time = "2023-09-11T21:42:34.514Z" },
-]
-
-[[package]]
-name = "furo"
-version = "2025.12.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "accessible-pygments" },
-    { name = "beautifulsoup4" },
-    { name = "pygments" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-basic-ng" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
 ]
 
 [[package]]
@@ -426,24 +244,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
-]
-
-[[package]]
-name = "imagesize"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
@@ -1032,30 +832,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.34.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "roman-numerals"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,185 +863,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "snowballstemmer"
-version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
-]
-
-[[package]]
-name = "soupsieve"
-version = "2.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
-]
-
-[[package]]
-name = "sphinx"
-version = "8.1.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
-]
-
-[[package]]
-name = "sphinx"
-version = "9.0.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.11.*'",
-]
-dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
-]
-
-[[package]]
-name = "sphinx"
-version = "9.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-]
-dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
-]
-
-[[package]]
-name = "sphinx-basic-ng"
-version = "1.0.0b2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-applehelp"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-devhelp"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-htmlhelp"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-jsmath"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-qthelp"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-serializinghtml"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
@@ -1332,17 +929,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "ruff" },
-    { name = "tox" },
-]
-docs = [
-    { name = "furo" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
 flask = [
     { name = "flask" },
 ]
@@ -1353,16 +939,6 @@ flask-sqlalchemy = [
     { name = "flask-sqlalchemy" },
 ]
 sqlmodel = [
-    { name = "sqlmodel" },
-]
-test = [
-    { name = "flask" },
-    { name = "flask-login" },
-    { name = "flask-sqlalchemy" },
-    { name = "packaging" },
-    { name = "psycopg2" },
-    { name = "pymysql" },
-    { name = "pytest" },
     { name = "sqlmodel" },
 ]
 
@@ -1378,6 +954,7 @@ dev = [
     { name = "pymysql" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "sqlmodel" },
     { name = "tox" },
     { name = "zensical" },
 ]
@@ -1396,30 +973,18 @@ test = [
     { name = "psycopg2" },
     { name = "pymysql" },
     { name = "pytest" },
+    { name = "sqlmodel" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "flask", marker = "extra == 'flask'", specifier = ">=0.9" },
-    { name = "flask", marker = "extra == 'test'", specifier = ">=0.9" },
-    { name = "flask-login", marker = "extra == 'flask-login'", specifier = ">=0.2.9" },
-    { name = "flask-login", marker = "extra == 'test'", specifier = ">=0.2.9" },
-    { name = "flask-sqlalchemy", marker = "extra == 'flask-sqlalchemy'", specifier = ">=1.0" },
-    { name = "flask-sqlalchemy", marker = "extra == 'test'", specifier = ">=1.0" },
-    { name = "furo", marker = "extra == 'docs'", specifier = ">=2021.11.0" },
-    { name = "packaging", marker = "extra == 'test'" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "psycopg2", marker = "extra == 'test'", specifier = ">=2.4.6" },
-    { name = "pymysql", marker = "extra == 'test'", specifier = ">=0.8.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=2.3.5" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=4.0.0" },
+    { name = "flask", marker = "extra == 'flask'", specifier = ">=2.0" },
+    { name = "flask-login", marker = "extra == 'flask-login'", specifier = ">=0.6" },
+    { name = "flask-sqlalchemy", marker = "extra == 'flask-sqlalchemy'", specifier = ">=3.0" },
     { name = "sqlalchemy", specifier = ">=1.4.53,<2.1" },
     { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.24" },
-    { name = "sqlmodel", marker = "extra == 'test'", specifier = ">=0.0.24" },
-    { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["test", "flask", "flask-login", "flask-sqlalchemy", "sqlmodel", "dev", "docs"]
+provides-extras = ["flask", "flask-login", "flask-sqlalchemy", "sqlmodel"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1433,6 +998,7 @@ dev = [
     { name = "pymysql", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "ruff", specifier = ">=0.15" },
+    { name = "sqlmodel", specifier = ">=0.0.24" },
     { name = "tox", specifier = ">=4.27" },
     { name = "zensical", specifier = ">=0.0.46" },
 ]
@@ -1449,6 +1015,7 @@ test = [
     { name = "psycopg2", specifier = ">=2.9" },
     { name = "pymysql", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=7.0" },
+    { name = "sqlmodel", specifier = ">=0.0.24" },
 ]
 
 [[package]]
@@ -1570,15 +1137,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is the SQLModel compatibility changes from [#363](https://github.com/sqlalchemy-continuum/sqlalchemy-continuum/pull/363) by @mksh with the aim to resolve [#271](https://github.com/sqlalchemy-continuum/sqlalchemy-continuum/issues/271#issuecomment-2521189305)

The following changes have been made on top of mksh's changes:

- Rebased changes on `main`.
- Updated SQLModel based tests to use SQLAlchemy 2.x style to address DeprecationWarning.
- Added ignore directive for SQLModel's DeprecationWarning of SQLAlchemy 1.x style queries.
- Updated uv.lock file.
